### PR TITLE
Set original version string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='sch_simulation',
-    version='0.0.1',
+    version='1.0.0',
     url='https://www.artrabbit.com/',
     maintainer='ArtRabbit',
     maintainer_email='support@artrabbit.com',


### PR DESCRIPTION
To be able to find this in future, in case we want to compare runs, this version will be tagged as v1.0.0, so make the setup file mirroring this will help with keeping clear what version is being used.