### PR TITLE
Alter mda method

### DIFF
--- a/sch_simulation/data/mansoni_params.txt
+++ b/sch_simulation/data/mansoni_params.txt
@@ -7,7 +7,8 @@ repNum	1		Number of repetitions
 nYears	23		Number of years to run
 nHosts	3000			Size of definitive host population (N)
 outputEvents	0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 132 133 134 135 136 137 138 139 140	output events.
-neverTreated	0.185
+neverTreated	0.185			never ever treated level of population
+systematic_non_compliance	0.3			level of systematic non compliance in range [0,1]
 
 ### Social structure
 contactAgeBreaks	0 5 10 16 80		Contact age group breaks (minus sign necessary to include zero age) anderson et al 2016 chp Iietune

--- a/sch_simulation/helsim_FUNC_KK/__init__.py
+++ b/sch_simulation/helsim_FUNC_KK/__init__.py
@@ -50,6 +50,8 @@ from sch_simulation.helsim_FUNC_KK.utils import (
     KKsampleGammaGammaPois,
     POC_CCA_test,
     PCR_test,
-    getSetOfEggCounts
+    getSetOfEggCounts,
+    checkForNaNTreatProbability,
+    editTreatProbability
 )
 

--- a/sch_simulation/helsim_FUNC_KK/__init__.py
+++ b/sch_simulation/helsim_FUNC_KK/__init__.py
@@ -51,7 +51,6 @@ from sch_simulation.helsim_FUNC_KK.utils import (
     POC_CCA_test,
     PCR_test,
     getSetOfEggCounts,
-    checkForNaNTreatProbability,
     editTreatProbability
 )
 

--- a/sch_simulation/helsim_FUNC_KK/configuration.py
+++ b/sch_simulation/helsim_FUNC_KK/configuration.py
@@ -14,7 +14,7 @@ from sch_simulation.helsim_FUNC_KK.helsim_structures import (
     SDEquilibrium,
     Worms,
 )
-from sch_simulation.helsim_FUNC_KK.utils import (getLifeSpans, getPsi)
+from sch_simulation.helsim_FUNC_KK.utils import (getLifeSpans, getPsi, drawTreatmentProbabilities)
 
 warnings.filterwarnings("ignore")
 
@@ -175,6 +175,10 @@ def setupSD(params: Parameters) -> SDEquilibrium:
     VaccTreatmentAgeGroupIndices = (
         np.digitize(-demography.birthDate, params.VaccTreatmentAgeGroupBreaks) - 1
     )
+    treatProbability = np.full(shape=params.N, fill_value=np.NaN, dtype=float)
+    if len(params.MDA[0].Coverage):
+        MDA_coverage = params.MDA[0].Coverage[0]
+        treatProbability = drawTreatmentProbabilities(params.N, MDA_coverage, params.systematic_non_compliance)
 
     SD = SDEquilibrium(
         si=si,
@@ -202,7 +206,9 @@ def setupSD(params: Parameters) -> SDEquilibrium:
         nChemo1 = 0,
         nChemo2 = 0, 
         id = ids,
-        treatProbability = np.full(shape=params.N, fill_value=np.NaN, dtype=float)
+        treatProbability = treatProbability,
+        MDA_coverage = MDA_coverage,
+        MDA_systematic_non_compliance = params.systematic_non_compliance
     )
 
 

--- a/sch_simulation/helsim_FUNC_KK/configuration.py
+++ b/sch_simulation/helsim_FUNC_KK/configuration.py
@@ -201,7 +201,8 @@ def setupSD(params: Parameters) -> SDEquilibrium:
         numSurvey=0,
         nChemo1 = 0,
         nChemo2 = 0, 
-        id = ids
+        id = ids,
+        treatProbability = np.ones(params.N, dtype=float) * (-1)
     )
 
 

--- a/sch_simulation/helsim_FUNC_KK/configuration.py
+++ b/sch_simulation/helsim_FUNC_KK/configuration.py
@@ -202,7 +202,7 @@ def setupSD(params: Parameters) -> SDEquilibrium:
         nChemo1 = 0,
         nChemo2 = 0, 
         id = ids,
-        treatProbability = np.ones(params.N, dtype=float) * (-1)
+        treatProbability = np.full(shape=params.N, fill_value=np.NaN, dtype=float)
     )
 
 

--- a/sch_simulation/helsim_FUNC_KK/events.py
+++ b/sch_simulation/helsim_FUNC_KK/events.py
@@ -280,7 +280,7 @@ def doDeath(params: Parameters, SD: SDEquilibrium, t: float) -> SDEquilibrium:
         maxID = max(SD.id)
         new_ids = np.arange(maxID + 1, maxID + len(theDead) + 1)
         SD.id[theDead] = new_ids
-        SD.treatProbability[theDead] = np.ones(len(theDead)) * (-1)
+        SD.treatProbability[theDead] = np.NaN
     assert params.contactAgeGroupBreaks is not None
     # update the contact age categories
     SD.contactAgeGroupIndices = (

--- a/sch_simulation/helsim_FUNC_KK/events.py
+++ b/sch_simulation/helsim_FUNC_KK/events.py
@@ -491,7 +491,6 @@ def doChemoAgeRange(
         SD.nChemo2 += len(k)
         numChemo2 += len(k)
         SD.n_treatments[
-            #str(mda_t) + ", MDA drug 2 (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
             str(mda_t) + ", MDA campaign " + str(label) + " (" + params.DrugName2 + ")"
             
         ] = counts2
@@ -501,7 +500,6 @@ def doChemoAgeRange(
             bins=np.arange(0, params.maxHostAge + 1),
         )
         SD.n_treatments_population[
-            #str(mda_t) + ", MDA drug 2 (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
             str(mda_t) + ", MDA campaign " + str(label) + " (" + params.DrugName2 + ")"
         ] = n_people_by_age
 
@@ -556,7 +554,6 @@ def doVaccine(
     ages = t - SD.demography.birthDate
     vaccs, _ = np.histogram(ages[vaccNow], bins=np.arange(params.maxHostAge + 1))
     SD.n_treatments[
-            #str(vacc_t) + ", Vaccination (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
             str(vacc_t) + ", Vaccination (campaign " + str(label) + ")"
         ] = vaccs
         
@@ -565,7 +562,6 @@ def doVaccine(
             bins=np.arange(0, params.maxHostAge + 1),
         )
     SD.n_treatments_population[
-            #str(vacc_t) + ", Vaccination (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
             str(vacc_t) + ", Vaccination (campaign " + str(label) + ")"
         ] = n_people_by_age
     return SD
@@ -613,7 +609,6 @@ def doVaccineAgeRange(
     propVacc = sum(vaccNow)/sum(correctAges)
     vaccs, _ = np.histogram(ages[vaccNow], bins=np.arange(params.maxHostAge + 1))
     SD.n_treatments[
-            #str(vacc_t) + ", Vaccination (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
             str(vacc_t) + ", Vaccination (campaign " + str(label) + ")"
         ] = vaccs
         
@@ -622,7 +617,6 @@ def doVaccineAgeRange(
             bins=np.arange(0, params.maxHostAge + 1),
         )
     SD.n_treatments_population[
-            #str(vacc_t) + ", Vaccination (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
             str(vacc_t) + ", Vaccination (campaign " + str(label) + ")"
         ] = n_people_by_age
     return SD, propVacc
@@ -771,10 +765,8 @@ def conductPCRSurvey(
 ) -> Tuple[SDEquilibrium, float]:
     minAge = params.minSurveyAge
     maxAge = params.maxSurveyAge
-    # minAge = 5
-    # maxAge = 15
+
     # get Kato-Katz eggs for each individual
-    
     
     PCR_antigen = PCR_test( SD.worms.total, SD.worms.female, params)
             

--- a/sch_simulation/helsim_FUNC_KK/events.py
+++ b/sch_simulation/helsim_FUNC_KK/events.py
@@ -323,13 +323,14 @@ def doChemo(
     """
 
     # decide which individuals are treated, treatment is random
-    attendance = (
-        np.random.uniform(low=0, high=1, size=params.N)
-        < coverage[SD.treatmentAgeGroupIndices]
-    )
+    # attendance = (
+    #     np.random.uniform(low=0, high=1, size=params.N)
+    #     < coverage[SD.treatmentAgeGroupIndices]
+    # )
+    toTreatNow = np.random.uniform(low=0, high=1, size=params.N) < SD.treatProbability
 
     # they're compliers and it's their turn
-    toTreatNow = np.logical_and(attendance, SD.compliers)
+    #toTreatNow = np.logical_and(attendance, SD.compliers)
 
     # calculate the number of dead worms
     femaleToDie = np.random.binomial(
@@ -390,14 +391,19 @@ def doChemoAgeRange(
     numChemo1 = 0
     numChemo2 = 0
     # decide which individuals are treated, treatment is random
-    attendance = np.random.uniform(low=0, high=1, size=params.N) < coverage
+    
+    #attendance = np.random.uniform(low=0, high=1, size=params.N) < coverage
+    attendance = np.random.uniform(low=0, high=1, size=params.N) < SD.treatProbability
+
     # get age of each individual
     ages = t - SD.demography.birthDate
     # choose individuals in correct age range
     correctAges = np.logical_and(ages < maxAge, ages >= minAge)
     # they're compliers, in the right age group and it's their turn
-    toTreatNow = np.logical_and(attendance, SD.compliers)
-    toTreatNow = np.logical_and(toTreatNow, correctAges)
+    # toTreatNow = np.logical_and(attendance, SD.compliers)
+    # toTreatNow = np.logical_and(toTreatNow, correctAges)
+
+    toTreatNow = np.logical_and(attendance, correctAges)
 
     # initialize the share of drug 1 and drug2
     # we allow 2 different types of drug to be given within the same MDA.

--- a/sch_simulation/helsim_FUNC_KK/events.py
+++ b/sch_simulation/helsim_FUNC_KK/events.py
@@ -280,6 +280,7 @@ def doDeath(params: Parameters, SD: SDEquilibrium, t: float) -> SDEquilibrium:
         maxID = max(SD.id)
         new_ids = np.arange(maxID + 1, maxID + len(theDead) + 1)
         SD.id[theDead] = new_ids
+        SD.treatProbability[theDead] = np.ones(len(theDead)) * (-1)
     assert params.contactAgeGroupBreaks is not None
     # update the contact age categories
     SD.contactAgeGroupIndices = (

--- a/sch_simulation/helsim_FUNC_KK/events.py
+++ b/sch_simulation/helsim_FUNC_KK/events.py
@@ -322,15 +322,9 @@ def doChemo(
         dataclass containing the updated equilibrium parameter values;
     """
 
-    # decide which individuals are treated, treatment is random
-    # attendance = (
-    #     np.random.uniform(low=0, high=1, size=params.N)
-    #     < coverage[SD.treatmentAgeGroupIndices]
-    # )
+    # decide which individuals are treated
     toTreatNow = np.random.uniform(low=0, high=1, size=params.N) < SD.treatProbability
 
-    # they're compliers and it's their turn
-    #toTreatNow = np.logical_and(attendance, SD.compliers)
 
     # calculate the number of dead worms
     femaleToDie = np.random.binomial(
@@ -390,18 +384,13 @@ def doChemoAgeRange(
     mda_t = t + label * 0.0001
     numChemo1 = 0
     numChemo2 = 0
-    # decide which individuals are treated, treatment is random
-    
-    #attendance = np.random.uniform(low=0, high=1, size=params.N) < coverage
+    # decide which individuals are treated
     attendance = np.random.uniform(low=0, high=1, size=params.N) < SD.treatProbability
 
     # get age of each individual
     ages = t - SD.demography.birthDate
     # choose individuals in correct age range
     correctAges = np.logical_and(ages < maxAge, ages >= minAge)
-    # they're compliers, in the right age group and it's their turn
-    # toTreatNow = np.logical_and(attendance, SD.compliers)
-    # toTreatNow = np.logical_and(toTreatNow, correctAges)
 
     toTreatNow = np.logical_and(attendance, correctAges)
 
@@ -433,11 +422,11 @@ def doChemoAgeRange(
             d1Share = 1
     # assign which drug each person will take
     drug = np.ones(int(sum(toTreatNow)))
-
+    # we want to make sure that if we are using drug 2, then the correct number of people are assigned this drug
     if d2Share > 0:
         k = random.sample(range(int(sum(drug))), int(sum(drug) * d2Share))
         drug[k] = 2
-# calculate the number of dead worms
+    # calculate the number of dead worms
     ll = np.where(toTreatNow==1)[0]
     # if drug 1 share is > 0, then treat the appropriate individuals with drug 1
     if d1Share > 0:
@@ -476,6 +465,7 @@ def doChemoAgeRange(
             #str(mda_t) + ", MDA drug 1 (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
             str(mda_t) + ", MDA campaign " + str(label) + " (" + params.DrugName1 + ")"
         ] = n_people_by_age
+        
     # if drug 2 share is > 0, then treat the appropriate individuals with drug 2
     if d2Share > 0:
         dEff = params.DrugEfficacy2

--- a/sch_simulation/helsim_FUNC_KK/events.py
+++ b/sch_simulation/helsim_FUNC_KK/events.py
@@ -7,7 +7,7 @@ from numpy import ndarray
 from numpy.typing import NDArray
 
 from sch_simulation.helsim_FUNC_KK.helsim_structures import Parameters, SDEquilibrium
-from sch_simulation.helsim_FUNC_KK.utils import getLifeSpans, getSetOfEggCounts, KKsampleGammaGammaPois,POC_CCA_test, PCR_test
+from sch_simulation.helsim_FUNC_KK.utils import getLifeSpans, getSetOfEggCounts, KKsampleGammaGammaPois,POC_CCA_test, PCR_test, drawTreatmentProbabilities
 
 warnings.filterwarnings("ignore")
 
@@ -280,7 +280,7 @@ def doDeath(params: Parameters, SD: SDEquilibrium, t: float) -> SDEquilibrium:
         maxID = max(SD.id)
         new_ids = np.arange(maxID + 1, maxID + len(theDead) + 1)
         SD.id[theDead] = new_ids
-        SD.treatProbability[theDead] = np.NaN
+        SD.treatProbability[theDead] = drawTreatmentProbabilities(len(theDead), SD.MDA_coverage, params.systematic_non_compliance)
     assert params.contactAgeGroupBreaks is not None
     # update the contact age categories
     SD.contactAgeGroupIndices = (

--- a/sch_simulation/helsim_FUNC_KK/file_parsing.py
+++ b/sch_simulation/helsim_FUNC_KK/file_parsing.py
@@ -577,6 +577,7 @@ def readParams(
 
     demographies = readParam(demogFileName)
     parameters = readParam(paramFileName)
+
     chemoTimings1 = np.array(
         [
             float(parameters["treatStart1"] + x * parameters["treatInterval1"])
@@ -619,7 +620,7 @@ def readParams(
         contactRates=parameters["betaValues"],
         v3=parameters["v3betaValues"],
         rho=parameters["rhoValues"],
-        snc = parameters["snc"],
+        systematic_non_compliance = parameters["systematic_non_compliance"],
         treatmentAgeBreaks=parameters["treatmentBreaks"],
         VaccTreatmentBreaks=parameters["VaccTreatmentBreaks"],
         coverage1=parameters["coverage1"],

--- a/sch_simulation/helsim_FUNC_KK/file_parsing.py
+++ b/sch_simulation/helsim_FUNC_KK/file_parsing.py
@@ -619,6 +619,7 @@ def readParams(
         contactRates=parameters["betaValues"],
         v3=parameters["v3betaValues"],
         rho=parameters["rhoValues"],
+        snc = parameters["snc"],
         treatmentAgeBreaks=parameters["treatmentBreaks"],
         VaccTreatmentBreaks=parameters["VaccTreatmentBreaks"],
         coverage1=parameters["coverage1"],

--- a/sch_simulation/helsim_FUNC_KK/helsim_structures.py
+++ b/sch_simulation/helsim_FUNC_KK/helsim_structures.py
@@ -176,7 +176,9 @@ class SDEquilibrium:
     sex_id: Optional[ndarray] = None
     nChemo1: Optional[int] = None
     nChemo2: Optional[int] = None
-    
+    MDA_coverage: Optional[float] = None
+    MDA_systematic_non_compliance: Optional[float] = None
+
 
 @dataclass
 class Result:

--- a/sch_simulation/helsim_FUNC_KK/helsim_structures.py
+++ b/sch_simulation/helsim_FUNC_KK/helsim_structures.py
@@ -54,6 +54,7 @@ class Parameters:
     gamma: float  # Exponential density dependence of parasite adult stage
     k: float  # Shape parameter of assumed negative binomial distribution of worms amongst host
     sigma: float  # Worm death rate
+    systematic_non_compliance: float # systematic non compliance for MDA
     v1: NDArray[
         np.float_
     ]  # impact of vaccine on worm death rate KK. Assume worm death rate is v1*sigma.
@@ -175,7 +176,6 @@ class SDEquilibrium:
     sex_id: Optional[ndarray] = None
     nChemo1: Optional[int] = None
     nChemo2: Optional[int] = None
-    
     
 
 @dataclass

--- a/sch_simulation/helsim_FUNC_KK/helsim_structures.py
+++ b/sch_simulation/helsim_FUNC_KK/helsim_structures.py
@@ -164,6 +164,7 @@ class SDEquilibrium:
     vaccCount: int
     numSurvey: int
     id: ndarray
+    treatProbability: ndarray
     n_treatments: Optional[dict[str, np.ndarray[np.float_]]]
     n_treatments_population: Optional[dict[str, np.ndarray[np.float_]]] 
     n_surveys: Optional[dict[str, np.ndarray[np.float_]]] 
@@ -174,6 +175,7 @@ class SDEquilibrium:
     sex_id: Optional[ndarray] = None
     nChemo1: Optional[int] = None
     nChemo2: Optional[int] = None
+    
     
 
 @dataclass

--- a/sch_simulation/helsim_FUNC_KK/utils.py
+++ b/sch_simulation/helsim_FUNC_KK/utils.py
@@ -421,8 +421,11 @@ def getPsi(params: Parameters) -> float:
     )
 
 def initializeTreatmentProbability(SD: SDEquilibrium, cov: float, snc: float) -> SDEquilibrium:
-
+    
     if(snc > 0):
+        # Define the parameters for the beta random number generator to get probability of treatment
+        # use scheme explained in section 1.5.3 of the suppplement of this paper
+        # https://www.sciencedirect.com/science/article/pii/S1755436516300810?via%3Dihub#sec0110
         alpha = cov * (1-snc)/snc
         beta = (1-cov)*(1-snc)/snc
         SD.treatProbability = np.random.beta(alpha, beta, len(SDEquilibrium.id))
@@ -438,6 +441,8 @@ def checkForZeroTreatProbability(SD: SDEquilibrium, cov: float, snc: float) -> S
     if len(notInitTreatmentProb) > 0:
         if(snc > 0):
             # Define the parameters for the beta random number generator to get probability of treatment
+            # use scheme explained in section 1.5.3 of the suppplement of this paper
+            # https://www.sciencedirect.com/science/article/pii/S1755436516300810?via%3Dihub#sec0110
             alpha = cov * (1-snc)/snc
             beta = (1-cov)*(1-snc)/snc
             # Draw probabilities from the beta distribution for each persons probability of being traeted

--- a/sch_simulation/helsim_FUNC_KK/utils.py
+++ b/sch_simulation/helsim_FUNC_KK/utils.py
@@ -430,3 +430,43 @@ def initializeTreatmentProbability(SD: SDEquilibrium, cov: float, snc: float) ->
         SD.treatProbability = np.ones(len(SDEquilibrium.id)) * cov
 
     return SD
+
+
+def checkForZeroTreatProbability(SD: SDEquilibrium, cov: float, snc: float) -> SDEquilibrium:
+    # if there are any people with value -1 for treatment probability they need to get values for this 
+    notInitTreatmentProb = np.where(SD.treatProbability == -1) 
+    if len(notInitTreatmentProb) > 0:
+        if(snc > 0):
+            alpha = cov * (1-snc)/snc
+            beta = (1-cov)*(1-snc)/snc
+            SD.treatProbability[notInitTreatmentProb] = np.random.beta(alpha, beta, len(notInitTreatmentProb))
+        else:
+            SD.treatProbability[notInitTreatmentProb] = np.ones(len(notInitTreatmentProb)) * cov           
+    return SD
+
+
+
+def editTreatProbability(SD: SDEquilibrium, cov: float, snc: float) -> SDEquilibrium:
+     
+    if snc > 0:
+        # Define the parameters for the probability of treatment
+        alpha = cov * (1 - snc) / snc
+        beta = (1 - cov) * (1 - snc) / snc
+
+        # Draw probabilities from the beta distribution
+        treatProbabilities = np.random.beta(alpha, beta, len(SDEquilibrium.id))
+        # Sort these values so that they are in ascending order
+        treatProbabilities.sort()
+
+        # Store the current value of the treatProbability in an array
+        oldTreatProbabilities = SD.treatProbability
+
+        # Sort the indices array based on the values in oldTreatProbabilities
+        indices = np.argsort(oldTreatProbabilities)
+        # Assign the newly drawn treatment probabilities to the appropriate individuals
+        for i, index in enumerate(indices):
+            SD[index].treatProbability = treatProbabilities[i]
+    else:
+        SD.treatProbability = np.ones(len(SDEquilibrium.id)) * cov
+
+    return SD

--- a/sch_simulation/helsim_FUNC_KK/utils.py
+++ b/sch_simulation/helsim_FUNC_KK/utils.py
@@ -461,7 +461,7 @@ def editTreatProbability(SD: SDEquilibrium, cov: float, snc: float) -> SDEquilib
         indices = np.argsort(oldTreatProbabilities)
         # Assign the newly drawn treatment probabilities to the appropriate individuals
         for i, index in enumerate(indices):
-            SD[index].treatProbability = treatProbabilities[i]
+            SD.treatProbability[index] = treatProbabilities[i]
     else:
         SD.treatProbability = np.ones(len(SDEquilibrium.id)) * cov
 

--- a/sch_simulation/helsim_FUNC_KK/utils.py
+++ b/sch_simulation/helsim_FUNC_KK/utils.py
@@ -437,8 +437,10 @@ def checkForZeroTreatProbability(SD: SDEquilibrium, cov: float, snc: float) -> S
     notInitTreatmentProb = np.where(SD.treatProbability == -1) 
     if len(notInitTreatmentProb) > 0:
         if(snc > 0):
+            # Define the parameters for the beta random number generator to get probability of treatment
             alpha = cov * (1-snc)/snc
             beta = (1-cov)*(1-snc)/snc
+            # Draw probabilities from the beta distribution for each persons probability of being traeted
             SD.treatProbability[notInitTreatmentProb] = np.random.beta(alpha, beta, len(notInitTreatmentProb))
         else:
             SD.treatProbability[notInitTreatmentProb] = np.ones(len(notInitTreatmentProb)) * cov           
@@ -447,18 +449,20 @@ def checkForZeroTreatProbability(SD: SDEquilibrium, cov: float, snc: float) -> S
 
 
 def editTreatProbability(SD: SDEquilibrium, cov: float, snc: float) -> SDEquilibrium:
-     
+    # we want to choose new values for treatment probability when the coverage or snc change
+    # this is done here, where we keep the rank of each individuals probability of treatment
+    # i.e. if previously you were the most likely person to get treated, you still will be after this
     if snc > 0:
-        # Define the parameters for the probability of treatment
+        # Define the parameters for the beta random number generator to get probability of treatment
         alpha = cov * (1 - snc) / snc
         beta = (1 - cov) * (1 - snc) / snc
 
         # Draw probabilities from the beta distribution
         treatProbabilities = np.random.beta(alpha, beta, len(SDEquilibrium.id))
-        # Sort these values so that they are in ascending order
+        # Sort these values so that they are in ascending order so they can later be matched with people
         treatProbabilities.sort()
 
-        # Store the current value of the treatProbability in an array
+        # Store the current value of the treatProbability 
         oldTreatProbabilities = SD.treatProbability
 
         # Sort the indices array based on the values in oldTreatProbabilities

--- a/sch_simulation/helsim_FUNC_KK/utils.py
+++ b/sch_simulation/helsim_FUNC_KK/utils.py
@@ -429,8 +429,9 @@ def drawTreatmentProbabilities(n:int, cov:float, snc:float):
     https://www.sciencedirect.com/science/article/pii/S1755436516300810?via%3Dihub#sec0110
     """
 
-    if(snc > 0):
-        
+    if(cov == 0):
+        treatmentProb = np.zeros(n)
+    elif(snc > 0):
         alpha = cov * (1-snc)/snc
         beta = (1-cov)*(1-snc)/snc
         treatmentProb = np.random.beta(alpha, beta, n)

--- a/sch_simulation/helsim_FUNC_KK/utils.py
+++ b/sch_simulation/helsim_FUNC_KK/utils.py
@@ -439,19 +439,6 @@ def drawTreatmentProbabilities(n:int, cov:float, snc:float):
     return treatmentProb
 
 
-def checkForNaNTreatProbability(SD: SDEquilibrium, cov: float, snc: float) -> SDEquilibrium:
-
-    """
-    If there are any people with NaN for treatment probability they need to get a value for this 
-    """
-
-    notInitTreatmentProb = np.where(np.isnan(SD.treatProbability)) 
-    if len(notInitTreatmentProb) > 0:
-        SD.treatProbability[notInitTreatmentProb] = drawTreatmentProbabilities(len(notInitTreatmentProb), cov, snc)
-    return SD
-
-
-
 def editTreatProbability(SD: SDEquilibrium, cov: float, snc: float) -> SDEquilibrium:
 
     """

--- a/sch_simulation/helsim_FUNC_KK/utils.py
+++ b/sch_simulation/helsim_FUNC_KK/utils.py
@@ -419,3 +419,14 @@ def getPsi(params: Parameters) -> float:
             * deltaT
         )
     )
+
+def initializeTreatmentProbability(SD: SDEquilibrium, cov: float, snc: float) -> SDEquilibrium:
+
+    if(snc > 0):
+        alpha = cov * (1-snc)/snc
+        beta = (1-cov)*(1-snc)/snc
+        SD.treatProbability = np.random.beta(alpha, beta, len(SDEquilibrium.id))
+    else:  # if snc = 0, then there is no variation between people in terms of probability of coverage
+        SD.treatProbability = np.ones(len(SDEquilibrium.id)) * cov
+
+    return SD

--- a/sch_simulation/helsim_RUN_KK.py
+++ b/sch_simulation/helsim_RUN_KK.py
@@ -46,7 +46,9 @@ from sch_simulation.helsim_FUNC_KK import (
     readCoverageFile,
     readParams,
     setupSD,
-    initializeTreatmentProbability
+    initializeTreatmentProbability,
+    checkForZeroTreatProbability,
+    editTreatProbability
 )
 
 num_cores = multiprocessing.cpu_count()
@@ -557,6 +559,15 @@ def doRealizationSurveyCoveragePickle(
                     k = nextMDAAge[i]
                     index = nextChemoIndex[i]
                     cov = params.MDA[k].Coverage[index]
+                    snc = params.snc
+                    if (cov != prevCov) | (snc != prevSNC):
+                        simData = checkForZeroTreatProbability(simData, prevCov, prevRho)
+                        simData = editTreatProbability(simData, cov, snc)
+                        prevCov = cov
+                        prevRho = snc
+
+                    simData = checkForZeroTreatProbability(simData, cov, snc)
+                    
                     minAge = params.MDA[k].Age[0]
                     maxAge = params.MDA[k].Age[1]
                     label = params.MDA[k].Label

--- a/sch_simulation/helsim_RUN_KK.py
+++ b/sch_simulation/helsim_RUN_KK.py
@@ -1035,7 +1035,7 @@ def multiple_simulations(
         deathDate=raw_data["demography"]["deathDate"],
     )
     ids = np.arange(len(raw_data["si"]))
-    treatProbability = np.ones(len(raw_data["si"])) *(-1)
+    treatProbability = np.full(shape=len(raw_data["si"]), fill_value=np.NaN, dtype=float)
     simData = SDEquilibrium(
         si=raw_data["si"],
         worms=worms,
@@ -1121,7 +1121,7 @@ def multiple_simulations(
         > params.propNeverCompliers,
         adherenceFactors=np.random.uniform(low=0, high=1, size=wantedPopSize),
         id = ids,
-        treatProbability=  np.ones(wantedPopSize) *(-1)
+        treatProbability= np.full(shape=wantedPopSize, fill_value=np.NaN, dtype=float) 
         )
         simData = copy.deepcopy(SD)
         

--- a/sch_simulation/helsim_RUN_KK.py
+++ b/sch_simulation/helsim_RUN_KK.py
@@ -452,6 +452,9 @@ def doRealizationSurveyCoveragePickle(
                                               params.Unfertilized, params.nSamples, surveyType)
                 # get approximate prevalence of the population
                 prev = len(np.where(eggCounts > 0)[0])/len(eggCounts)
+                # we have to check if this is the first time that the output is being done in order
+                # to get the incidence in this time step, as if there are no previous results
+                # then there is nothing to compare the currently infected people against
                 if len(results) > 0:
                     l = len(results)
                     # get ids of people who had 0 eggs last time step
@@ -1014,6 +1017,7 @@ def multiple_simulations(
         deathDate=raw_data["demography"]["deathDate"],
     )
     ids = np.arange(len(raw_data["si"]))
+    treatProbability = np.ones(len(raw_data["si"])) *(-1)
     simData = SDEquilibrium(
         si=raw_data["si"],
         worms=worms,
@@ -1036,7 +1040,8 @@ def multiple_simulations(
         compliers=np.random.uniform(low=0, high=1, size=len(raw_data["si"]))
         > params.propNeverCompliers,
         adherenceFactors=np.random.uniform(low=0, high=1, size=len(raw_data["si"])),
-        id = ids
+        id = ids,
+        treatProbability= treatProbability
     )
     pickleNumIndivs = len(simData.si)
     #print("starting  j =",j)
@@ -1097,7 +1102,8 @@ def multiple_simulations(
         compliers=np.random.uniform(low=0, high=1, size=wantedPopSize)
         > params.propNeverCompliers,
         adherenceFactors=np.random.uniform(low=0, high=1, size=wantedPopSize),
-        id = ids
+        id = ids,
+        treatProbability=  np.ones(wantedPopSize) *(-1)
         )
         simData = copy.deepcopy(SD)
         
@@ -1186,7 +1192,8 @@ def multiple_simulations_after_burnin(
         compliers=np.random.uniform(low=0, high=1, size=len(raw_data.si))
         > params.propNeverCompliers,
         adherenceFactors=np.random.uniform(low=0, high=1, size=len(raw_data.si)),
-        id = np.arange(len(raw_data.si))
+        id = np.arange(len(raw_data.si)),
+        treatProbability = np.ones(len(raw_data.si)) *(-1)
     )
     
     # Convert all layers to correct data format

--- a/sch_simulation/helsim_RUN_KK.py
+++ b/sch_simulation/helsim_RUN_KK.py
@@ -547,7 +547,7 @@ def doRealizationSurveyCoveragePickle(
                 
                 if nChemo == 0: # if this is the first MDA, then we need to initialize everyone's probability of treatment
                     cov = params.MDA[0].Coverage[0]
-                    snc = params.snc
+                    snc = params.systematic_non_compliance
                     simData = checkForNaNTreatProbability(simData, cov, snc)
                     prevCov = cov # save the coverage used, so that we can check if we need to update the treatment probabilities
                     prevSNC = snc
@@ -558,14 +558,14 @@ def doRealizationSurveyCoveragePickle(
                     k = nextMDAAge[i]
                     index = nextChemoIndex[i]
                     cov = params.MDA[k].Coverage[index]
-                    snc = params.snc
+                    snc = params.systematic_non_compliance
                     if (cov != prevCov) | (snc != prevSNC):
-                        simData = checkForNaNTreatProbability(simData, prevCov, prevRho)
+                        simData = checkForNaNTreatProbability(simData, prevCov, prevSNC)
                         simData = editTreatProbability(simData, cov, snc)
                         prevCov = cov
-                        prevRho = snc
-
-                    simData = checkForNaNTreatProbability(simData, cov, snc)
+                        prevSNC = snc
+                    else:
+                        simData = checkForNaNTreatProbability(simData, cov, snc)
                     
                     minAge = params.MDA[k].Age[0]
                     maxAge = params.MDA[k].Age[1]

--- a/sch_simulation/helsim_RUN_KK.py
+++ b/sch_simulation/helsim_RUN_KK.py
@@ -46,8 +46,7 @@ from sch_simulation.helsim_FUNC_KK import (
     readCoverageFile,
     readParams,
     setupSD,
-    initializeTreatmentProbability,
-    checkForZeroTreatProbability,
+    checkForNaNTreatProbability,
     editTreatProbability
 )
 
@@ -549,7 +548,7 @@ def doRealizationSurveyCoveragePickle(
                 if nChemo == 0: # if this is the first MDA, then we need to initialize everyone's probability of treatment
                     cov = params.MDA[0].Coverage[0]
                     snc = params.snc
-                    simData = initializeTreatmentProbability(simData, cov, snc)
+                    simData = checkForNaNTreatProbability(simData, cov, snc)
                     prevCov = cov # save the coverage used, so that we can check if we need to update the treatment probabilities
                     prevSNC = snc
                 
@@ -561,12 +560,12 @@ def doRealizationSurveyCoveragePickle(
                     cov = params.MDA[k].Coverage[index]
                     snc = params.snc
                     if (cov != prevCov) | (snc != prevSNC):
-                        simData = checkForZeroTreatProbability(simData, prevCov, prevRho)
+                        simData = checkForNaNTreatProbability(simData, prevCov, prevRho)
                         simData = editTreatProbability(simData, cov, snc)
                         prevCov = cov
                         prevRho = snc
 
-                    simData = checkForZeroTreatProbability(simData, cov, snc)
+                    simData = checkForNaNTreatProbability(simData, cov, snc)
                     
                     minAge = params.MDA[k].Age[0]
                     maxAge = params.MDA[k].Age[1]

--- a/sch_simulation/helsim_RUN_KK.py
+++ b/sch_simulation/helsim_RUN_KK.py
@@ -46,6 +46,7 @@ from sch_simulation.helsim_FUNC_KK import (
     readCoverageFile,
     readParams,
     setupSD,
+    initializeTreatmentProbability
 )
 
 num_cores = multiprocessing.cpu_count()
@@ -542,7 +543,14 @@ def doRealizationSurveyCoveragePickle(
                 
             # chemotherapy
             if timeBarrier >= nextChemoTime:
-                #print("MDA, time = ", t)           
+                
+                if nChemo == 0: # if this is the first MDA, then we need to initialize everyone's probability of treatment
+                    cov = params.MDA[0].Coverage[0]
+                    snc = params.snc
+                    simData = initializeTreatmentProbability(simData, cov, snc)
+                    prevCov = cov # save the coverage used, so that we can check if we need to update the treatment probabilities
+                    prevSNC = snc
+                
                 simData = doDeath(params, simData, t)
                 assert params.MDA is not None
                 for i in range(len(nextMDAAge)):


### PR DESCRIPTION
Align the MDA method with other diseases using beta random variables for probability of treatment based on coverage and snc values. When coverage or snc change, the probability of treatment will change for everyone, but the rank of probability will stay the same, e.g. the person who was most likely to get treated with the previous coverage and snc will still be the person most likely to get treated after the change.

When the population is initialized everyone is assigned a "treatProbability" of -1. At the first MDA, this value is updated for everyone. When someone dies, this is set to -1 again.  At subsequent MDA's, if there is a different value of coverage or snc from the previous MDA then we first check for anyone with a -1 value, so that we can give them a value for treatProbability with the old coverage and snc, then they can be properly ranked alongside everyone else.

Requires the parameter file to have an "snc" parameter now, as this is read in when loading parameters.