### PR TITLE
Avoid running CI twice when pushing to PR branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Currently the CI workflow runs twice when pushing commits to a branch for which a PR is opened.

This changes the workflow configuration so that it runs only once (according to the `pull_request` directive), but also
sets the CI to run whenever commits are pushed to the main branch (i.e. after the PR is merged).