### PR TITLE
Fix linter errors (`E`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,32 @@
-name: CI
+name: Lint, format and tests
 
 on: [push, pull_request]
 
 jobs:
-  build:
+
+  ruff-check:
     runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v3
+      with:
+        python-version: "3.12"
+    - run: pip install ruff==0.4.*
+    - run: ruff check sch_simulation/
+
+  ruff-format-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v3
+      with:
+        python-version: "3.12"
+    - run: pip install ruff==0.4.*
+    - run: ruff format --check sch_simulation/
+
+  install-and-test:
+    runs-on: ubuntu-latest
+    needs: [ruff-check, ruff-format-check]
     strategy:
       matrix:
         # Test oldest and newest supported Python

--- a/sch_simulation/amis_integration/amis_integration.py
+++ b/sch_simulation/amis_integration/amis_integration.py
@@ -15,6 +15,7 @@ import sch_simulation.helsim_RUN_KK
 
 import sch_simulation.helsim_FUNC_KK.results_processing as results_processing
 
+
 @dataclass(eq=True, frozen=True)
 class FixedParameters:
     number_hosts: int
@@ -46,7 +47,9 @@ class FixedParameters:
 
 @cache
 def returnYearlyPrevalenceEstimate(R0, k, fixed_parameters: FixedParameters):
-    cov = parse_coverage_input(
+    # Run `parse_coverage_input` for side-effect of writing coverage
+    # text file.
+    parse_coverage_input(
         fixed_parameters.coverage_file_name,
         fixed_parameters.coverage_text_file_storage_name,
     )

--- a/sch_simulation/helsim_FUNC_KK/ParallelFuncs.py
+++ b/sch_simulation/helsim_FUNC_KK/ParallelFuncs.py
@@ -4,7 +4,6 @@ from sch_simulation.helsim_FUNC_KK.helsim_structures import Parameters
 
 
 def epgPerPerson(x: np.ndarray, params: Parameters) -> np.ndarray:
-
     """
     This function calculates the total eggs per gram as
     a function of the mean worm burden.
@@ -26,7 +25,6 @@ def epgPerPerson(x: np.ndarray, params: Parameters) -> np.ndarray:
 
 
 def fertilityFunc(x: np.ndarray, params: Parameters) -> np.ndarray:
-
     """
     This function calculates the multiplicative fertility correction factor
     to be applied to the mean eggs per person function.
@@ -47,7 +45,6 @@ def fertilityFunc(x: np.ndarray, params: Parameters) -> np.ndarray:
 
 
 def monogFertilityFuncApprox(x: float, params: Parameters):
-
     """
     This function calculates the fertility factor for monogamously mating worms.
 
@@ -62,11 +59,9 @@ def monogFertilityFuncApprox(x: float, params: Parameters):
     """
     assert params.monogParams is not None
     if x > 25 * params.k:
-
         return 1 - params.monogParams.c_k / np.sqrt(x)
 
     else:
-
         g = x / (x + params.k)
         integrand = (1 - params.monogParams.cosTheta) * (
             1 + float(g) * params.monogParams.cosTheta
@@ -77,7 +72,6 @@ def monogFertilityFuncApprox(x: float, params: Parameters):
 
 
 def epgMonog(x: np.ndarray, params: Parameters) -> np.ndarray:
-
     """
     This function calculates the generation of eggs with monogamous
     reproduction taken into account.
@@ -95,7 +89,6 @@ def epgMonog(x: np.ndarray, params: Parameters) -> np.ndarray:
 
 
 def epgFertility(x: np.ndarray, params: Parameters) -> np.ndarray:
-
     """
     This function calculates the generation of eggs with
     sexual reproduction taken into account.

--- a/sch_simulation/helsim_FUNC_KK/__init__.py
+++ b/sch_simulation/helsim_FUNC_KK/__init__.py
@@ -4,7 +4,7 @@ from . import (
     file_parsing,
     helsim_structures,
     results_processing,
-    utils
+    utils,
 )
 
 __all__ = [

--- a/sch_simulation/helsim_FUNC_KK/configuration.py
+++ b/sch_simulation/helsim_FUNC_KK/configuration.py
@@ -14,7 +14,7 @@ from sch_simulation.helsim_FUNC_KK.helsim_structures import (
     SDEquilibrium,
     Worms,
 )
-from sch_simulation.helsim_FUNC_KK.utils import (getLifeSpans, getPsi)
+from sch_simulation.helsim_FUNC_KK.utils import getLifeSpans, getPsi
 
 warnings.filterwarnings("ignore")
 
@@ -22,7 +22,6 @@ np.seterr(divide="ignore")
 
 
 def monogFertilityConfig(params: Parameters, N: int = 30) -> MonogParameters:
-
     """
     This function calculates the monogamous fertility
     function parameters.
@@ -42,7 +41,6 @@ def monogFertilityConfig(params: Parameters, N: int = 30) -> MonogParameters:
 
 
 def configure(params: Parameters) -> Parameters:
-
     """
     This function defines a number of additional parameters.
     Parameters
@@ -109,7 +107,6 @@ def configure(params: Parameters) -> Parameters:
 
 
 def setupSD(params: Parameters) -> SDEquilibrium:
-
     """
     This function sets up the simulation to initial conditions
     based on analytical equilibria.
@@ -136,7 +133,6 @@ def setupSD(params: Parameters) -> SDEquilibrium:
     communityBurnIn = 1000
     ids = np.arange(params.N)
     while np.min(trialDeathDates) < communityBurnIn:
-
         earlyDeath = np.where(trialDeathDates < communityBurnIn)[0]
         trialBirthDates[earlyDeath] = trialDeathDates[earlyDeath]
         trialDeathDates[earlyDeath] += getLifeSpans(len(earlyDeath), params)
@@ -193,23 +189,21 @@ def setupSD(params: Parameters) -> SDEquilibrium:
         attendanceRecord=[],
         ageAtChemo=[],
         adherenceFactorAtChemo=[],
-        n_treatments = {},
-        n_treatments_population = {},
-        n_surveys = {},
-        n_surveys_population = {},
+        n_treatments={},
+        n_treatments_population={},
+        n_surveys={},
+        n_surveys_population={},
         vaccCount=0,
         numSurvey=0,
-        nChemo1 = 0,
-        nChemo2 = 0, 
-        id = ids
+        nChemo1=0,
+        nChemo2=0,
+        id=ids,
     )
-
 
     return SD
 
 
 def getEquilibrium(params: Parameters) -> Equilibrium:
-
     """
     This function returns a dictionary containing the equilibrium worm burden
     with age and the reservoir value as well as the breakpoint reservoir value
@@ -264,7 +258,7 @@ def getEquilibrium(params: Parameters) -> Equilibrium:
         * (params.R0**R_power - 1)
         / (params.R0 * MeanLifespan * params.LDecayRate * (1 - params.z))
     )
- 
+
     # now evaluate the function K across a series of L values and find point near breakpoint;
     # L_minus is the value that gives an age-averaged worm burden of 1; negative growth should
     # exist somewhere below this
@@ -294,7 +288,6 @@ def getEquilibrium(params: Parameters) -> Equilibrium:
     mid_L = test_L[iMax]
 
     if K_values[iMax] < 0:
-
         return Equilibrium(
             stableProfile=0 * Q,
             ageValues=modelAges,

--- a/sch_simulation/helsim_FUNC_KK/events.py
+++ b/sch_simulation/helsim_FUNC_KK/events.py
@@ -697,7 +697,7 @@ def conductKKSurvey(
     sampledEggs = eggCounts[sample_indices]
     # get the number of people of each age that are surveyed
     surveys, _ = np.histogram(ages[sample_indices], bins=np.arange(params.maxHostAge + 1))
-    if writeSurvey == True:
+    if writeSurvey:
         # add this to the SD n surveys dict
         SD.n_surveys[
                 str(t) + "," + str("surveys")
@@ -748,7 +748,7 @@ def conductPOCCCASurvey(
     samples = surveyPOC_CCA[sample_indices]
     # get the number of people of each age that are surveyed
     surveys, _ = np.histogram(ages[sample_indices], bins=np.arange(params.maxHostAge + 1))
-    if writeSurvey == True:
+    if writeSurvey:
     # add this to the SD n surveys dict
         SD.n_surveys[
                 str(t) + "," + str("surveys")

--- a/sch_simulation/helsim_FUNC_KK/events.py
+++ b/sch_simulation/helsim_FUNC_KK/events.py
@@ -7,7 +7,12 @@ from numpy import ndarray
 from numpy.typing import NDArray
 
 from sch_simulation.helsim_FUNC_KK.helsim_structures import Parameters, SDEquilibrium
-from sch_simulation.helsim_FUNC_KK.utils import getLifeSpans, getSetOfEggCounts, KKsampleGammaGammaPois,POC_CCA_test, PCR_test
+from sch_simulation.helsim_FUNC_KK.utils import (
+    getLifeSpans,
+    getSetOfEggCounts,
+    POC_CCA_test,
+    PCR_test,
+)
 
 warnings.filterwarnings("ignore")
 
@@ -17,7 +22,6 @@ np.seterr(divide="ignore")
 def doEvent(
     rates: NDArray[np.float_], params: Parameters, SD: SDEquilibrium
 ) -> SDEquilibrium:
-
     """
     This function enacts the event; the events are
     new worms, worms death and vaccine recoveries
@@ -41,7 +45,6 @@ def doEvent(
     )
 
     if event == len(rates) - 1:  # worm death event
-
         deathIndex = np.argmax(
             np.random.uniform(low=0, high=1, size=1)
             * np.sum(SD.worms.total * params.v1[SD.sv])
@@ -75,7 +78,6 @@ def doEvent2(
     SD: SDEquilibrium,
     multiplier: int = 1,
 ) -> SDEquilibrium:
-
     """
     This function enacts the event; the events are
     new worms, worms death and vaccine recoveries
@@ -178,7 +180,6 @@ def doRegular(
 
 
 def doFreeLive(params: Parameters, SD: SDEquilibrium, dt: float) -> SDEquilibrium:
-
     """
     This function updates the freeliving population deterministically.
     Parameters
@@ -233,7 +234,6 @@ def doFreeLive(params: Parameters, SD: SDEquilibrium, dt: float) -> SDEquilibriu
 
 
 def doDeath(params: Parameters, SD: SDEquilibrium, t: float) -> SDEquilibrium:
-
     """
     Death and aging function.
     Parameters
@@ -302,7 +302,6 @@ def doDeath(params: Parameters, SD: SDEquilibrium, t: float) -> SDEquilibrium:
 def doChemo(
     params: Parameters, SD: SDEquilibrium, t: NDArray[np.int_], coverage: ndarray
 ) -> SDEquilibrium:
-
     """
     Chemoterapy function.
     Parameters
@@ -359,10 +358,8 @@ def doChemoAgeRange(
     minAge: int,
     maxAge: int,
     coverage: ndarray,
-    label:int,
-    
+    label: int,
 ) -> SDEquilibrium:
-
     """
     Chemoterapy function.
     Parameters
@@ -400,7 +397,7 @@ def doChemoAgeRange(
 
     # initialize the share of drug 1 and drug2
     # we allow 2 different types of drug to be given within the same MDA.
-    # Hence we need to split the population into groups who will take each of the drugs. 
+    # Hence we need to split the population into groups who will take each of the drugs.
     # in reality it will often be just one of the drugs each year, making this redundant
     d1Share = 0
     d2Share = 0
@@ -418,7 +415,7 @@ def doChemoAgeRange(
         j = np.where(params.drug2Years == t)[0][0]
         d2Share = params.drug2Split[j]
 
-    # ensure that a drug is assigned even if missed in the coverage file    
+    # ensure that a drug is assigned even if missed in the coverage file
     if np.logical_and(d1Share == 0, d2Share == 0):
         if max(params.drug1Years) < t:
             d2Share = 1
@@ -430,17 +427,15 @@ def doChemoAgeRange(
     if d2Share > 0:
         k = random.sample(range(int(sum(drug))), int(sum(drug) * d2Share))
         drug[k] = 2
-# calculate the number of dead worms
-    ll = np.where(toTreatNow==1)[0]
+    # calculate the number of dead worms
+    ll = np.where(toTreatNow == 1)[0]
     # if drug 1 share is > 0, then treat the appropriate individuals with drug 1
     if d1Share > 0:
         dEff = params.DrugEfficacy1
         k = np.where(drug == 1)[0]
 
         femaleToDie = np.random.binomial(
-            size=len(k), 
-            n=np.array(SD.worms.female[ll[k]], dtype="int32"), 
-            p=dEff
+            size=len(k), n=np.array(SD.worms.female[ll[k]], dtype="int32"), p=dEff
         )
 
         maleToDie = np.random.binomial(
@@ -458,7 +453,7 @@ def doChemoAgeRange(
         SD.nChemo1 += len(k)
         numChemo1 += len(k)
         SD.n_treatments[
-            #str(mda_t) + ", MDA drug 1 (campaign " + str(label) + str(int(minAge)) + "-" + str(int(maxAge)) + ", )"
+            # str(mda_t) + ", MDA drug 1 (campaign " + str(label) + str(int(minAge)) + "-" + str(int(maxAge)) + ", )"
             str(mda_t) + ", MDA campaign " + str(label) + " (" + params.DrugName1 + ")"
         ] = counts1
         n_people_by_age, _ = np.histogram(
@@ -466,7 +461,7 @@ def doChemoAgeRange(
             bins=np.arange(0, params.maxHostAge + 1),
         )
         SD.n_treatments_population[
-            #str(mda_t) + ", MDA drug 1 (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
+            # str(mda_t) + ", MDA drug 1 (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
             str(mda_t) + ", MDA campaign " + str(label) + " (" + params.DrugName1 + ")"
         ] = n_people_by_age
     # if drug 2 share is > 0, then treat the appropriate individuals with drug 2
@@ -475,9 +470,7 @@ def doChemoAgeRange(
         k = np.where(drug == 2)[0]
 
         femaleToDie = np.random.binomial(
-            size=len(k),
-            n=np.array(SD.worms.female[ll[k]], dtype="int32"),
-            p=dEff
+            size=len(k), n=np.array(SD.worms.female[ll[k]], dtype="int32"), p=dEff
         )
 
         maleToDie = np.random.binomial(
@@ -494,9 +487,8 @@ def doChemoAgeRange(
         SD.nChemo2 += len(k)
         numChemo2 += len(k)
         SD.n_treatments[
-            #str(mda_t) + ", MDA drug 2 (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
+            # str(mda_t) + ", MDA drug 2 (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
             str(mda_t) + ", MDA campaign " + str(label) + " (" + params.DrugName2 + ")"
-            
         ] = counts2
 
         n_people_by_age, _ = np.histogram(
@@ -504,11 +496,10 @@ def doChemoAgeRange(
             bins=np.arange(0, params.maxHostAge + 1),
         )
         SD.n_treatments_population[
-            #str(mda_t) + ", MDA drug 2 (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
+            # str(mda_t) + ", MDA drug 2 (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
             str(mda_t) + ", MDA campaign " + str(label) + " (" + params.DrugName2 + ")"
         ] = n_people_by_age
 
-    
     propTreated1 = numChemo1 / sum(correctAges)
     propTreated2 = numChemo2 / sum(correctAges)
     SD.ageAtChemo.append(t - SD.demography.birthDate)
@@ -518,9 +509,9 @@ def doChemoAgeRange(
 
 
 def doVaccine(
-    params: Parameters, 
-    SD: SDEquilibrium, 
-    t: int, 
+    params: Parameters,
+    SD: SDEquilibrium,
+    t: int,
     VaccCoverage: ndarray,
     label: int,
 ) -> SDEquilibrium:
@@ -545,7 +536,7 @@ def doVaccine(
     assert SD.VaccTreatmentAgeGroupIndices is not None
     temp = ((SD.VaccTreatmentAgeGroupIndices + 1) // 2) - 1
     vaccinate = np.random.uniform(low=0, high=1, size=params.N) < VaccCoverage[temp]
-    
+
     indicesToVaccinate = []
     for i in range(len(params.VaccTreatmentBreaks)):
         indicesToVaccinate.append(1 + i * 2)
@@ -559,18 +550,18 @@ def doVaccine(
     ages = t - SD.demography.birthDate
     vaccs, _ = np.histogram(ages[vaccNow], bins=np.arange(params.maxHostAge + 1))
     SD.n_treatments[
-            #str(vacc_t) + ", Vaccination (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
-            str(vacc_t) + ", Vaccination (campaign " + str(label) + ")"
-        ] = vaccs
-        
+        # str(vacc_t) + ", Vaccination (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
+        str(vacc_t) + ", Vaccination (campaign " + str(label) + ")"
+    ] = vaccs
+
     n_people_by_age, _ = np.histogram(
-            ages,
-            bins=np.arange(0, params.maxHostAge + 1),
-        )
+        ages,
+        bins=np.arange(0, params.maxHostAge + 1),
+    )
     SD.n_treatments_population[
-            #str(vacc_t) + ", Vaccination (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
-            str(vacc_t) + ", Vaccination (campaign " + str(label) + ")"
-        ] = n_people_by_age
+        # str(vacc_t) + ", Vaccination (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
+        str(vacc_t) + ", Vaccination (campaign " + str(label) + ")"
+    ] = n_people_by_age
     return SD
 
 
@@ -609,25 +600,25 @@ def doVaccineAgeRange(
     ages = t - SD.demography.birthDate
     correctAges = np.logical_and(ages <= maxAge, ages >= minAge)
     # they're compliers and it's their turn
-    #vaccNow = np.logical_and(vaccinate, SD.compliers)
+    # vaccNow = np.logical_and(vaccinate, SD.compliers)
     vaccNow = np.logical_and(vaccinate, correctAges)
     SD.sv[vaccNow] = 1
     SD.vaccCount += sum(vaccNow)
-    propVacc = sum(vaccNow)/sum(correctAges)
+    propVacc = sum(vaccNow) / sum(correctAges)
     vaccs, _ = np.histogram(ages[vaccNow], bins=np.arange(params.maxHostAge + 1))
     SD.n_treatments[
-            #str(vacc_t) + ", Vaccination (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
-            str(vacc_t) + ", Vaccination (campaign " + str(label) + ")"
-        ] = vaccs
-        
+        # str(vacc_t) + ", Vaccination (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
+        str(vacc_t) + ", Vaccination (campaign " + str(label) + ")"
+    ] = vaccs
+
     n_people_by_age, _ = np.histogram(
-            ages,
-            bins=np.arange(0, params.maxHostAge + 1),
-        )
+        ages,
+        bins=np.arange(0, params.maxHostAge + 1),
+    )
     SD.n_treatments_population[
-            #str(vacc_t) + ", Vaccination (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
-            str(vacc_t) + ", Vaccination (campaign " + str(label) + ")"
-        ] = n_people_by_age
+        # str(vacc_t) + ", Vaccination (" + str(int(minAge)) + "-" + str(int(maxAge)) + ")"
+        str(vacc_t) + ", Vaccination (campaign " + str(label) + ")"
+    ] = n_people_by_age
     return SD, propVacc
 
 
@@ -635,7 +626,7 @@ def doVectorControl(
     params: Parameters,
     SD: SDEquilibrium,
     vectorCoverage: ndarray,
-    ) -> SDEquilibrium:
+) -> SDEquilibrium:
     """
     Vector control function.
     Parameters
@@ -652,40 +643,48 @@ def doVectorControl(
         dataclass containing the updated equilibrium parameter values;
     """
     SD.freeLiving = SD.freeLiving * (1 - vectorCoverage)
-    
+
     return SD
 
+
 def conductKKSurvey(
-        SD: SDEquilibrium, params: Parameters, t: float, sampleSize: int, nSamples: int, surveyType: str, writeSurvey: bool,
+    SD: SDEquilibrium,
+    params: Parameters,
+    t: float,
+    sampleSize: int,
+    nSamples: int,
+    surveyType: str,
+    writeSurvey: bool,
 ) -> Tuple[SDEquilibrium, float]:
-    
     minAge = params.minSurveyAge
     maxAge = params.maxSurveyAge
-   
+
     # get Kato-Katz eggs for each individual
     # if nSamples < 1:
     #     raise ValueError("nSamples < 1")
 
-
-
-    if surveyType == 'KK1':
+    if surveyType == "KK1":
         nSamples = 1
-    else: 
+    else:
         nSamples = 2
         # eggCounts = KKsampleGammaGammaPois(
         #     SD.worms.total, SD.worms.female, SD.sv, params,  params.Unfertilized, nSamples
         #     )
-    eggCounts = getSetOfEggCounts(SD.worms.total, SD.worms.female, SD.sv, params,  params.Unfertilized, nSamples, surveyType)
-    
-        
+    eggCounts = getSetOfEggCounts(
+        SD.worms.total,
+        SD.worms.female,
+        SD.sv,
+        params,
+        params.Unfertilized,
+        nSamples,
+        surveyType,
+    )
+
     eggCounts = eggCounts / nSamples
 
     # get individuals in chosen survey age group
     ages = -(SD.demography.birthDate - t)
     surveyAged = np.logical_and(ages >= minAge, ages <= maxAge)
-
-    # get egg counts for those individuals
-    surveyEggs = eggCounts[surveyAged]
 
     # get number of samples to take
     KKSampleSize = min(sampleSize, sum(surveyAged))
@@ -696,41 +695,39 @@ def conductKKSurvey(
     # get the eggs for these sampled people
     sampledEggs = eggCounts[sample_indices]
     # get the number of people of each age that are surveyed
-    surveys, _ = np.histogram(ages[sample_indices], bins=np.arange(params.maxHostAge + 1))
+    surveys, _ = np.histogram(
+        ages[sample_indices], bins=np.arange(params.maxHostAge + 1)
+    )
     if writeSurvey:
         # add this to the SD n surveys dict
-        SD.n_surveys[
-                str(t) + "," + str("surveys")
-            ] = surveys
+        SD.n_surveys[str(t) + "," + str("surveys")] = surveys
         # get the number of people in each age group
         n_people_by_age, _ = np.histogram(
-                ages,
-                bins=np.arange(0, params.maxHostAge + 1),
-            )
+            ages,
+            bins=np.arange(0, params.maxHostAge + 1),
+        )
         # add this to the SD n survey population dict
-        SD.n_surveys_population[
-                str(t) + "," + str("surveys")
-            ] = n_people_by_age
-        
+        SD.n_surveys_population[str(t) + "," + str("surveys")] = n_people_by_age
+
     positivity = np.count_nonzero(sampledEggs) / KKSampleSize
-    return SD, positivity 
-
-
+    return SD, positivity
 
 
 def conductPOCCCASurvey(
-        SD: SDEquilibrium, params: Parameters, t: float, sampleSize: int,  writeSurvey: bool,
+    SD: SDEquilibrium,
+    params: Parameters,
+    t: float,
+    sampleSize: int,
+    writeSurvey: bool,
 ) -> Tuple[SDEquilibrium, float]:
     minAge = params.minSurveyAge
     maxAge = params.maxSurveyAge
     # minAge = 5
     # maxAge = 15
     # get Kato-Katz eggs for each individual
-    
-    
-    POC_CCA_antigen = POC_CCA_test( SD.worms.total, params)
-            
-    
+
+    POC_CCA_antigen = POC_CCA_test(SD.worms.total, params)
+
     # get individuals in chosen survey age group
     ages = -(SD.demography.birthDate - t)
     surveyAged = np.logical_and(ages >= minAge, ages <= maxAge)
@@ -743,45 +740,43 @@ def conductPOCCCASurvey(
     # which people are in the required age range
     true_indices = np.where(surveyAged)[0]
     # sample from these people
-    sample_indices = np.random.choice(true_indices, size=POC_CCA_SampleSize, replace=False)
+    sample_indices = np.random.choice(
+        true_indices, size=POC_CCA_SampleSize, replace=False
+    )
     # get the eggs for these sampled people
     samples = surveyPOC_CCA[sample_indices]
     # get the number of people of each age that are surveyed
-    surveys, _ = np.histogram(ages[sample_indices], bins=np.arange(params.maxHostAge + 1))
+    surveys, _ = np.histogram(
+        ages[sample_indices], bins=np.arange(params.maxHostAge + 1)
+    )
     if writeSurvey:
-    # add this to the SD n surveys dict
-        SD.n_surveys[
-                str(t) + "," + str("surveys")
-            ] = surveys
+        # add this to the SD n surveys dict
+        SD.n_surveys[str(t) + "," + str("surveys")] = surveys
         # get the number of people in each age group
         n_people_by_age, _ = np.histogram(
-                ages,
-                bins=np.arange(0, params.maxHostAge + 1),
-            )
+            ages,
+            bins=np.arange(0, params.maxHostAge + 1),
+        )
         # add this to the SD n survey population dict
-        SD.n_surveys_population[
-                str(t) + "," + str("surveys")
-            ] = n_people_by_age
+        SD.n_surveys_population[str(t) + "," + str("surveys")] = n_people_by_age
         # sampledPOC_CCA = np.random.choice(
         #     a=np.array(surveyPOC_CCA), size=int(POC_CCA_SampleSize), replace=False
     # )
     positivity = sum(samples > 0) / POC_CCA_SampleSize
-    return SD, positivity 
+    return SD, positivity
 
 
 def conductPCRSurvey(
-        SD: SDEquilibrium, params: Parameters, t: float, sampleSize: int
+    SD: SDEquilibrium, params: Parameters, t: float, sampleSize: int
 ) -> Tuple[SDEquilibrium, float]:
     minAge = params.minSurveyAge
     maxAge = params.maxSurveyAge
     # minAge = 5
     # maxAge = 15
     # get Kato-Katz eggs for each individual
-    
-    
-    PCR_antigen = PCR_test( SD.worms.total, SD.worms.female, params)
-            
-    
+
+    PCR_antigen = PCR_test(SD.worms.total, SD.worms.female, params)
+
     # get individuals in chosen survey age group
     ages = -(SD.demography.birthDate - t)
     surveyAged = np.logical_and(ages >= minAge, ages <= maxAge)
@@ -796,50 +791,64 @@ def conductPCRSurvey(
         a=np.array(surveyPCR), size=int(PCR_SampleSize), replace=False
     )
     positivity = sum(sampledPCR > 0) / PCR_SampleSize
-    return positivity 
+    return positivity
+
 
 def conductSurvey(
-    SD: SDEquilibrium, params: Parameters, t: float, sampleSize: int, nSamples: int, surveyType: str, writeSurvey: bool
+    SD: SDEquilibrium,
+    params: Parameters,
+    t: float,
+    sampleSize: int,
+    nSamples: int,
+    surveyType: str,
+    writeSurvey: bool,
 ) -> Tuple[SDEquilibrium, float]:
     # get min and max age for survey
     if sampleSize > 0:
-        if (surveyType == 'KK1') | (surveyType == 'KK2'):
-            SD, positivity = conductKKSurvey(SD, params, t, sampleSize, nSamples, surveyType, writeSurvey)
-        if surveyType == 'POC-CCA':
+        if (surveyType == "KK1") | (surveyType == "KK2"):
+            SD, positivity = conductKKSurvey(
+                SD, params, t, sampleSize, nSamples, surveyType, writeSurvey
+            )
+        if surveyType == "POC-CCA":
             SD, positivity = conductPOCCCASurvey(SD, params, t, sampleSize, writeSurvey)
-        if surveyType == 'PCR':
+        if surveyType == "PCR":
             positivity = conductPCRSurvey(SD, params, t, sampleSize)
         SD.numSurvey += 1
     else:
         ages = -(SD.demography.birthDate - t)
-        
+
         # get the number of people in each age group
         n_people_by_age, _ = np.histogram(
-                ages,
-                bins=np.arange(0, params.maxHostAge + 1),
-            )
+            ages,
+            bins=np.arange(0, params.maxHostAge + 1),
+        )
         # add this to the SD n survey population dict
-        SD.n_surveys_population[
-                str(t) + "," + str("surveys")
-            ] = n_people_by_age
-        SD.n_surveys[
-                str(t) + "," + str("surveys")
-            ] = np.zeros(len(n_people_by_age))
+        SD.n_surveys_population[str(t) + "," + str("surveys")] = n_people_by_age
+        SD.n_surveys[str(t) + "," + str("surveys")] = np.zeros(len(n_people_by_age))
         positivity = 0
     # return the prevalence
     return SD, positivity
 
 
 def conductSurveyTwo(
-    SD: SDEquilibrium, params: Parameters, t: float, sampleSize: int, nSamples: int, surveyType: int
+    SD: SDEquilibrium,
+    params: Parameters,
+    t: float,
+    sampleSize: int,
+    nSamples: int,
+    surveyType: int,
 ) -> Tuple[SDEquilibrium, float]:
-
     # get Kato-Katz eggs for each individual
     if nSamples < 1:
         raise ValueError("nSamples < 1")
     eggCounts = getSetOfEggCounts(
-        SD.worms.total, SD.worms.female, SD.sv, params, params.Unfertilized,  nSamples,
-        surveyType
+        SD.worms.total,
+        SD.worms.female,
+        SD.sv,
+        params,
+        params.Unfertilized,
+        nSamples,
+        surveyType,
     )
     for _ in range(nSamples):
         eggCounts = np.add(
@@ -851,7 +860,7 @@ def conductSurveyTwo(
                 params,
                 params.Unfertilized,
                 nSamples,
-                surveyType
+                surveyType,
             ),
         )
     eggCounts = eggCounts / nSamples

--- a/sch_simulation/helsim_FUNC_KK/file_parsing.py
+++ b/sch_simulation/helsim_FUNC_KK/file_parsing.py
@@ -125,7 +125,7 @@ def parse_coverage_input(
     fy = 10000
     fy_index = 10000
     for i in range(len(PlatCov.columns)):
-        if type(PlatCov.columns[i]) == int:
+        if isinstance(PlatCov.columns[i], int):
             fy = min(fy, PlatCov.columns[i])
             fy_index = min(fy_index, i)
 
@@ -280,7 +280,7 @@ def parse_coverage_input(
     fy = 10000
     fy_index = 10000
     for i in range(len(MarketShare.columns)):
-        if type(MarketShare.columns[i]) == int:
+        if isinstance(MarketShare.columns[i], int):
             fy = min(fy, MarketShare.columns[i])
             fy_index = min(fy_index, i)
 
@@ -361,7 +361,7 @@ def parse_vector_control_input(
         fy = 10000
         fy_index = 10000
         for i in range(len(PlatCov.columns)):
-            if type(PlatCov.columns[i]) == int:
+            if isinstance(PlatCov.columns[i],  int):
                 fy = min(fy, PlatCov.columns[i])
                 fy_index = min(fy_index, i)
             
@@ -433,7 +433,7 @@ def nextMDAVaccInfo(
     
     for i in range(len(params.Vacc)):
         k = copy.deepcopy(params.Vacc[i])
-        if type(k.Years) == float:
+        if isinstance(k.Years, float):
             y1 = k.Years
             c1 = k.Coverage
             k.Years = [y1,1000]
@@ -444,7 +444,7 @@ def nextMDAVaccInfo(
     
     for i in range(len(params.MDA)):
         k = copy.deepcopy(params.MDA[i])
-        if type(k.Years) == float:
+        if isinstance(k.Years, float):
             y1 = k.Years
             c1 = k.Coverage
             k.Years = [y1,1000]

--- a/sch_simulation/helsim_FUNC_KK/file_parsing.py
+++ b/sch_simulation/helsim_FUNC_KK/file_parsing.py
@@ -7,7 +7,11 @@ import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
 
-from sch_simulation.helsim_FUNC_KK.helsim_structures import Coverage, Parameters, VecControl
+from sch_simulation.helsim_FUNC_KK.helsim_structures import (
+    Coverage,
+    Parameters,
+    VecControl,
+)
 from sch_simulation import DATA_PATH
 
 warnings.filterwarnings("ignore")
@@ -40,7 +44,6 @@ def params_from_contents(contents: List[str]) -> Dict[str, Any]:
 
 
 def readParam(fileName: str) -> Dict[str, Any]:
-
     """
     This function extracts the parameter values stored
     in the input text files into a dictionary.
@@ -62,7 +65,6 @@ def readParam(fileName: str) -> Dict[str, Any]:
 
 
 def readCovFile(fileName: str) -> Dict[str, Any]:
-
     """
     This function extracts the parameter values stored
     in the input text files into a dictionary.
@@ -115,7 +117,6 @@ def parse_coverage_input(
     MDAAges = np.zeros([len(MDARows), 2])
     MDAYears = []
     MDACoverages = []
-    MDADrugs = []
     VaccAges = np.zeros([len(VaccRows), 2])
     VaccYears = []
     VaccCoverages = []
@@ -181,8 +182,8 @@ def parse_coverage_input(
         # re initilize the coverage and years data
         MDAYears = []
         MDACoverages = []
-        
-        #drugIndex = np.where(PlatCov.columns == "Drug")
+
+        # drugIndex = np.where(PlatCov.columns == "Drug")
 
         # loop over the yearly data for this row
         for j in range(fy_index, len(PlatCov.columns)):
@@ -192,7 +193,7 @@ def parse_coverage_input(
             if w[cname] > 0:
                 MDAYears.append(cname)
                 MDACoverages.append(w[cname])
-                
+
         MDA_txt = (
             MDA_txt
             + "MDA_age"
@@ -216,8 +217,6 @@ def parse_coverage_input(
             else:
                 MDA_txt = MDA_txt + str(MDACoverages[k]) + " "
 
-
-    
     # loop over Vaccination coverage rows
     for i in range(len(VaccRows)):
         # get row number of each MDA entry
@@ -262,7 +261,9 @@ def parse_coverage_input(
                 Vacc_txt = Vacc_txt + str(VaccCoverages[k]) + " "
 
     # read in market share data
-    MarketShare = pd.read_excel(DATA_PATH / Path(coverageFileName), sheet_name="MarketShare")
+    MarketShare = pd.read_excel(
+        DATA_PATH / Path(coverageFileName), sheet_name="MarketShare"
+    )
     # find which rows store data for MDAs
     MDAMarketShare = np.where(np.array(MarketShare["Platform"] == "MDA"))[0]
     # initialize variable to store which drug is being used
@@ -320,7 +321,7 @@ def parse_coverage_input(
             else:
                 MDA_txt = MDA_txt + str(MDAYearSplit[k]) + " "
 
-    coverageText = MDA_txt + Vacc_txt + 'start_year\t'+ str(fy) +"\n"
+    coverageText = MDA_txt + Vacc_txt + "start_year\t" + str(fy) + "\n"
     # store the Coverage data in a text file
     with open(coverageTextFileStorageName, "w", encoding="utf-8") as f:
         f.write(coverageText)
@@ -354,21 +355,19 @@ def parse_vector_control_input(
     intervention_array = PlatCov["Intervention Type"]
     VectorControl = np.where(np.array(intervention_array == "Vector Control"))[0]
     if len(VectorControl) == 0:
-        VecControlInfo = VecControl(Years = [1000000,10000000], Coverage = [0.01,0.01])
+        VecControlInfo = VecControl(Years=[1000000, 10000000], Coverage=[0.01, 0.01])
     else:
         # we want to find which is the first year specified in the coverage data, along with which
         # column of the data set this corresponds to
         fy = 10000
         fy_index = 10000
         for i in range(len(PlatCov.columns)):
-            if isinstance(PlatCov.columns[i],  int):
+            if isinstance(PlatCov.columns[i], int):
                 fy = min(fy, PlatCov.columns[i])
                 fy_index = min(fy_index, i)
-            
-        
-        VecControlInfo = VecControl(Years = [], Coverage = [])
-        
-        
+
+        VecControlInfo = VecControl(Years=[], Coverage=[])
+
         # for each non-zero entry of the vector control data add an entry to the parameters object
         for i in range(len(VectorControl)):
             k = VectorControl[i]
@@ -376,32 +375,29 @@ def parse_vector_control_input(
             for j in range(fy_index, len(PlatCov.columns)):
                 cname = PlatCov.columns[j]
                 if w[cname] > 0:
-                    VecControlInfo.Years.append(cname-fy)
+                    VecControlInfo.Years.append(cname - fy)
                     VecControlInfo.Coverage.append(w[cname])
-                
+
     params.VecControl = [VecControlInfo]
 
     return params
 
 
-
 def readCoverageFile(
     coverageTextFileStorageName: str, params: Parameters
 ) -> Parameters:
-
     coverage = readCovFile(coverageTextFileStorageName)
 
     nMDAAges = int(coverage["nMDAAges"])
     nVaccAges = int(coverage["nVaccAges"])
     mda_covs = []
-    
+
     for i in range(nMDAAges):
         cov = Coverage(
             Age=coverage["MDA_age" + str(i + 1)],
             Years=coverage["MDA_Years" + str(i + 1)] - coverage["start_year"],
             Coverage=coverage["MDA_Coverage" + str(i + 1)],
             Label=i + 1,
-
         )
         mda_covs.append(cov)
     params.MDA = mda_covs
@@ -412,7 +408,6 @@ def readCoverageFile(
             Years=coverage["Vacc_Years" + str(i + 1)] - coverage["start_year"],
             Coverage=coverage["Vacc_Coverage" + str(i + 1)],
             Label=i + 1,
-
         )
         vacc_covs.append(cov)
     params.Vacc = vacc_covs
@@ -423,31 +418,28 @@ def readCoverageFile(
     return params
 
 
-
 def nextMDAVaccInfo(
     params: Parameters,
 ) -> Tuple[Dict, Dict, int, List[int], List[int], int, List[int], List[int]]:
     chemoTiming = {}
     assert params.MDA is not None
     assert params.Vacc is not None
-    
+
     for i in range(len(params.Vacc)):
         k = copy.deepcopy(params.Vacc[i])
         if isinstance(k.Years, float):
             y1 = k.Years
             c1 = k.Coverage
-            k.Years = [y1,1000]
+            k.Years = [y1, 1000]
             k.Coverage = [c1, 0]
             params.Vacc[i] = k
-            
-            
-    
+
     for i in range(len(params.MDA)):
         k = copy.deepcopy(params.MDA[i])
         if isinstance(k.Years, float):
             y1 = k.Years
             c1 = k.Coverage
-            k.Years = [y1,1000]
+            k.Years = [y1, 1000]
             k.Coverage = [c1, 0]
             params.MDA[i] = k
     chemoTiming = {}
@@ -458,7 +450,7 @@ def nextMDAVaccInfo(
         VaccTiming["Age{0}".format(i)] = copy.deepcopy(np.array(vacc.Years))
     VecControlTiming = {}
     for i, vecControl in enumerate(params.VecControl):
-        VecControlTiming["Time".format(i)] = copy.deepcopy(vecControl.Years)    
+        VecControlTiming["Time"] = copy.deepcopy(vecControl.Years)
     #  currentVaccineTimings = copy.deepcopy(params['VaccineTimings'])
 
     nextChemoTime = 10000
@@ -484,13 +476,13 @@ def nextMDAVaccInfo(
     for i in range(len(nextVaccAge)):
         k = nextVaccAge[i]
         nextVaccIndex.append(np.argmin(np.array(VaccTiming["Age{0}".format(k)])))
-      
+
     nextVecControlTime = 10000
     for i, vecControl in enumerate(params.VecControl):
-        nextVecControlTime = min(nextVecControlTime, min(VecControlTiming ["Time".format(i)]))
+        nextVecControlTime = min(nextVecControlTime, min(VecControlTiming["Time"]))
     nextVecControlIndex = []
-    for i in range(len(VecControlTiming['Time'])):
-        k = copy.deepcopy(VecControlTiming['Time'][i])
+    for i in range(len(VecControlTiming["Time"])):
+        k = copy.deepcopy(VecControlTiming["Time"][i])
         if k == nextVecControlTime:
             nextVecControlIndex = i
 
@@ -522,7 +514,6 @@ def overWritePostVacc(
     return params
 
 
-
 def overWritePostMDA(
     params: Parameters,
     nextMDAAge: Union[NDArray[np.int_], List[int]],
@@ -537,17 +528,15 @@ def overWritePostMDA(
     return params
 
 
-
 def overWritePostVecControl(
     params: Parameters,
-    nextVecControlIndex:int,
+    nextVecControlIndex: int,
 ):
     assert params.VecControl is not None
-    
+
     params.VecControl[0].Years[nextVecControlIndex] = 10000
 
     return params
-
 
 
 def readParams(
@@ -555,7 +544,6 @@ def readParams(
     demogFileName: str = "Demographies.txt",
     demogName: str = "Default",
 ) -> Parameters:
-
     """
     This function organizes the model parameters and
     the demography parameters into a unique dictionary.
@@ -611,8 +599,8 @@ def readParams(
         DrugEfficacy=parameters["drugEff"],
         DrugEfficacy1=parameters["drugEff1"],
         DrugEfficacy2=parameters["drugEff2"],
-        DrugName1 = parameters["drugName1"],
-        DrugName2 = parameters["drugName2"],
+        DrugName1=parameters["drugName1"],
+        DrugName2=parameters["drugName2"],
         contactAgeBreaks=parameters["contactAgeBreaks"],
         contactRates=parameters["betaValues"],
         v3=parameters["v3betaValues"],
@@ -658,11 +646,11 @@ def readParams(
         timeToNextSurvey=parameters["timeToNextSurvey"],
         surveyThreshold=parameters["surveyThreshold"],
         Unfertilized=parameters["unfertilized"],
-        k_within = parameters["k_within"],
-        k_slide = parameters["k_slide"],
-        weight_sample = parameters["weight_sample"],
-        testSensitivity = parameters["testSensitivity"],
-        testSpecificity = parameters["testSpecificity"]
+        k_within=parameters["k_within"],
+        k_slide=parameters["k_slide"],
+        weight_sample=parameters["weight_sample"],
+        testSensitivity=parameters["testSensitivity"],
+        testSpecificity=parameters["testSpecificity"],
     )
 
     return params

--- a/sch_simulation/helsim_FUNC_KK/helsim_structures.py
+++ b/sch_simulation/helsim_FUNC_KK/helsim_structures.py
@@ -35,13 +35,13 @@ class Coverage:
     Years: ndarray  # 1-D array lower/upper
     Coverage: ndarray  # 1-D array
     Label: ndarray  # 1-D array
-    
+
 
 @dataclass
 class VecControl:
     Years: ndarray  # 1-D array lower/upper
     Coverage: ndarray  # 1-D array
-    
+
 
 @dataclass
 class Parameters:
@@ -66,7 +66,9 @@ class Parameters:
     contactAgeBreaks: ndarray  # 1-D array - Contact age group breaks (minus sign necessary to include zero age)
     contactRates: ndarray  # 1-D array - BetaValues: Relative contact rates
     v3: ndarray  # 1-D array, v3 beta values: impact of vaccine on contact rates  Assume contact rate under vaccination is times v3. KK
-    rho: ndarray  # 1-D array, - Rho, contribution to the reservoir by contact age group.
+    rho: (
+        ndarray  # 1-D array, - Rho, contribution to the reservoir by contact age group.
+    )
     treatmentAgeBreaks: ndarray  # 1-D array, treatmentBreaks Minimum age of each treatment group (minus sign necessary to include zero age): Infants; Pre-SAC; SAC; Adults
     VaccTreatmentBreaks: ndarray  # 1-D array, age range of vaccinated group.  ## KK: these are the lower bounds of ranges with width 1. THEY MUST BE > 1 YEAR APART!!
     coverage1: ndarray
@@ -90,7 +92,9 @@ class Parameters:
     VaccTreatStart: float  ##Vaccine administration year start KK
     nRoundsVacc: int  ##number of vaccine rounds KK
     treatIntervalVacc: float  # KK
-    heavyThreshold: int  # The threshold for heavy burden of infection, egg count > heavyThreshold
+    heavyThreshold: (
+        int  # The threshold for heavy burden of infection, egg count > heavyThreshold
+    )
     mediumThreshold: int  # The threshold of medium burden of infection, mediumThreshold <= egg count <= heavyThreshold
     sampleSizeOne: int
     sampleSizeTwo: int
@@ -165,16 +169,16 @@ class SDEquilibrium:
     numSurvey: int
     id: ndarray
     n_treatments: Optional[dict[str, np.ndarray[np.float_]]]
-    n_treatments_population: Optional[dict[str, np.ndarray[np.float_]]] 
-    n_surveys: Optional[dict[str, np.ndarray[np.float_]]] 
-    n_surveys_population: Optional[dict[str, np.ndarray[np.float_]]] 
+    n_treatments_population: Optional[dict[str, np.ndarray[np.float_]]]
+    n_surveys: Optional[dict[str, np.ndarray[np.float_]]]
+    n_surveys_population: Optional[dict[str, np.ndarray[np.float_]]]
     numSurveyTwo: Optional[int] = None
     vaccinatedFactors: Optional[ndarray] = None
     VaccTreatmentAgeGroupIndices: Optional[ndarray] = None
     sex_id: Optional[ndarray] = None
     nChemo1: Optional[int] = None
     nChemo2: Optional[int] = None
-    
+
 
 @dataclass
 class Result:
@@ -203,11 +207,7 @@ class Result:
     propChemo1: Optional[ndarray] = None
     propChemo2: Optional[ndarray] = None
     propVacc: Optional[ndarray] = None
-    
-    
-    
-    
-    
+
 
 @dataclass
 class ProcResult:
@@ -217,4 +217,3 @@ class ProcResult:
     ages: ndarray
     timePoints: ndarray
     prevalence: ndarray
-    

--- a/sch_simulation/helsim_FUNC_KK/results_processing.py
+++ b/sch_simulation/helsim_FUNC_KK/results_processing.py
@@ -12,7 +12,11 @@ from sch_simulation.helsim_FUNC_KK.helsim_structures import (
     Result,
     SDEquilibrium,
 )
-from sch_simulation.helsim_FUNC_KK.utils import getSetOfEggCounts, getSetOfEggCountsv2, POC_CCA_test, PCR_test
+from sch_simulation.helsim_FUNC_KK.utils import (
+    getSetOfEggCounts,
+    getSetOfEggCountsv2,
+    POC_CCA_test,
+)
 
 warnings.filterwarnings("ignore")
 
@@ -22,8 +26,8 @@ np.seterr(divide="ignore")
 # draw_1.
 OUTPUT_COLUMN_NAME = "draw_1"
 
-def extractHostData(results: List[List[Result]]) -> List[ProcResult]:
 
+def extractHostData(results: List[List[Result]]) -> List[ProcResult]:
     """
     This function is used for processing results the raw simulation results.
     Parameters
@@ -39,33 +43,30 @@ def extractHostData(results: List[List[Result]]) -> List[ProcResult]:
     output = []
 
     for result in results:
-
         output.append(
             ProcResult(
-                vaccState = np.array(
-                    [result[i].vaccState for i in range(len(result))]
-                ).T,
+                vaccState=np.array([result[i].vaccState for i in range(len(result))]).T,
                 wormsOverTime=np.array(
                     [result[i].worms.total for i in range(len(result))]
                 ).T,
                 femaleWormsOverTime=np.array(
-                    [result[i].worms.female for i in range(len(result) )]
+                    [result[i].worms.female for i in range(len(result))]
                 ).T,
                 # freeLiving=np.array([result[i]['freeLiving'] for i in range(len(results[0]) - 1)]),
                 ages=np.array(
                     [
                         result[i].time - result[i].hosts.birthDate
-                        for i in range(len(result) )
+                        for i in range(len(result))
                     ]
                 ).T,
                 # adherenceFactors=np.array([result[i]['adherenceFactors'] for i in range(len(results[0]) - 1)]).T,
                 # compliers=np.array([result[i]['compliers'] for i in range(len(results[0]) - 1)]).T,
                 # totalPop=len(result[0]['worms']['total']),
                 timePoints=np.array(
-                    [np.array(result[i].time) for i in range(len(result) )]
+                    [np.array(result[i].time) for i in range(len(result))]
                 ),
-                prevalence = np.array(
-                    [np.array(result[i].prevalence) for i in range(len(result) )]
+                prevalence=np.array(
+                    [np.array(result[i].prevalence) for i in range(len(result))]
                 ),
                 # attendanceRecord=result[-1]['attendanceRecord'],
                 # ageAtChemo=result[-1]['ageAtChemo'],
@@ -84,7 +85,7 @@ def getVillageMeanCountsByHost(
     params: Parameters,
     Unfertilized: bool,
     nSamples: int = 2,
-    surveyType: str = "KK2"
+    surveyType: str = "KK2",
 ) -> NDArray[np.float_]:
     """
     This function returns the mean egg count across readings by host
@@ -112,11 +113,10 @@ def getVillageMeanCountsByHost(
             params,
             Unfertilized,
             nSamples,
-            surveyType
+            surveyType,
         )
         / nSamples
     )
-
 
     return meanEggsByHost
 
@@ -127,7 +127,7 @@ def getVillageMeanCountsByHostv2(
     params: Parameters,
     Unfertilized: bool,
     nSamples: int = 2,
-    surveyType: str = "KK2"
+    surveyType: str = "KK2",
 ) -> NDArray[np.float_]:
     """
     This function returns the mean egg count across readings by host
@@ -155,14 +155,12 @@ def getVillageMeanCountsByHostv2(
             params,
             Unfertilized,
             nSamples,
-            surveyType
+            surveyType,
         )
         / nSamples
     )
 
-
     return meanEggsByHost
-
 
 
 def getVillagePOCCCAByHost(
@@ -191,14 +189,10 @@ def getVillagePOCCCAByHost(
     array of mean egg counts;
     """
 
-    mean_POCCCA = POC_CCA_test(
-        villageList.wormsOverTime[:, timeIndex],
-        params)
-    
+    mean_POCCCA = POC_CCA_test(villageList.wormsOverTime[:, timeIndex], params)
+
     for i in range(1, nSamples):
-        mean_POCCCA += POC_CCA_test(
-            villageList.wormsOverTime[:, timeIndex],
-            params)
+        mean_POCCCA += POC_CCA_test(villageList.wormsOverTime[:, timeIndex], params)
 
     return mean_POCCCA / nSamples
 
@@ -211,9 +205,8 @@ def getAgeCatSampledPrevByVillage(
     Unfertilized: bool,
     nSamples: int = 2,
     villageSampleSize: int = 100,
-    surveyType: str = 'KK2'
+    surveyType: str = "KK2",
 ) -> float:
-
     """
     This function provides sampled, age-cat worm prevalence
     for a given time point and iteration.
@@ -242,11 +235,8 @@ def getAgeCatSampledPrevByVillage(
         villageList, timeIndex, params, Unfertilized, nSamples
     )
 
-    ageGroups = (
-        np.digitize(
-            villageList.ages[:, timeIndex], np.append(-10, np.append(ageBand, 150))
-        )
-        
+    ageGroups = np.digitize(
+        villageList.ages[:, timeIndex], np.append(-10, np.append(ageBand, 150))
     )
 
     currentAgeGroupMeanEggCounts = meanEggCounts[ageGroups == 2]
@@ -270,11 +260,10 @@ def getAgeCatSampledPrevByVillageAll(
     ageBand: NDArray[np.int_],
     params: Parameters,
     Unfertilized: bool,
-    surveyType: str = 'KK2',
+    surveyType: str = "KK2",
     nSamples: int = 2,
     villageSampleSize=100,
 ) -> Tuple[ndarray, ndarray, ndarray, ndarray, ndarray, ndarray]:
-
     """
     This function provides sampled, age-cat worm prevalence
     for a given time point and iteration.
@@ -298,18 +287,18 @@ def getAgeCatSampledPrevByVillageAll(
     -------
     sampled worm prevalence;
     """
-   
-    if ((surveyType == "KK1") | (surveyType == "KK2")):
+
+    if (surveyType == "KK1") | (surveyType == "KK2"):
         meanEggCounts = getVillageMeanCountsByHost(
             villageList, timeIndex, params, Unfertilized, nSamples, surveyType
         )
         ages = villageList.ages[:, timeIndex]
-    
+
         currentAges = np.where(np.logical_and(ages >= ageBand[0], ages < ageBand[1]))
         currentAgeGroupMeanEggCounts = meanEggCounts[currentAges]
-    
+
         is_empty = currentAgeGroupMeanEggCounts.size == 0
-        
+
         if is_empty:
             infected = np.nan
             low = np.nan
@@ -317,28 +306,30 @@ def getAgeCatSampledPrevByVillageAll(
             heavy = np.nan
             meanEggs = np.nan
         else:
-    
-            infected = np.sum(currentAgeGroupMeanEggCounts>0)/len(currentAgeGroupMeanEggCounts)
-            #meanEggCounts = getVillageMeanCountsByHost(
+            infected = np.sum(currentAgeGroupMeanEggCounts > 0) / len(
+                currentAgeGroupMeanEggCounts
+            )
+            # meanEggCounts = getVillageMeanCountsByHost(
             #     villageList, timeIndex, params, Unfertilized, nSamples, surveyType
-            #)
+            # )
             ages = villageList.ages[:, timeIndex]
-        
-            currentAges = np.where(np.logical_and(ages >= ageBand[0], ages < ageBand[1]))
+
+            currentAges = np.where(
+                np.logical_and(ages >= ageBand[0], ages < ageBand[1])
+            )
             currentAgeGroupMeanEggCounts = meanEggCounts[currentAges]
-        
+
             is_empty = currentAgeGroupMeanEggCounts.size == 0
             # print("mod thr4esh = ", params.mediumThreshold)
             # print("heav thr4esh = ", params.heavyThreshold)
-            medium = (
-                np.sum(
-                    (currentAgeGroupMeanEggCounts >= params.mediumThreshold)
-                    & (currentAgeGroupMeanEggCounts <= params.heavyThreshold)
-                )
-                /len(currentAgeGroupMeanEggCounts)
+            medium = np.sum(
+                (currentAgeGroupMeanEggCounts >= params.mediumThreshold)
+                & (currentAgeGroupMeanEggCounts <= params.heavyThreshold)
+            ) / len(currentAgeGroupMeanEggCounts)
+
+            heavy = np.sum(currentAgeGroupMeanEggCounts > params.heavyThreshold) / len(
+                currentAgeGroupMeanEggCounts
             )
-            
-            heavy = np.sum(currentAgeGroupMeanEggCounts > params.heavyThreshold) / len(currentAgeGroupMeanEggCounts)
             # print(currentAgeGroupMeanEggCounts)
             # print("heavy infs = " , heavy)
             low = infected - (medium + heavy)
@@ -349,23 +340,21 @@ def getAgeCatSampledPrevByVillageAll(
             np.array(medium),
             np.array(heavy),
             np.array(len(currentAgeGroupMeanEggCounts)),
-            np.array(meanEggs)
+            np.array(meanEggs),
         )
-    
-    
-    
+
     if surveyType == "POC-CCA":
         meanPOCCCA = getVillagePOCCCAByHost(
             villageList, timeIndex, params, Unfertilized, surveyType, nSamples
-        ) 
-    
+        )
+
         ages = villageList.ages[:, timeIndex]
-    
+
         currentAges = np.where(np.logical_and(ages >= ageBand[0], ages < ageBand[1]))
         currentAgeGroupMeanEggCounts = meanPOCCCA[currentAges]
-    
+
         is_empty = currentAgeGroupMeanEggCounts.size == 0
-        
+
         if is_empty:
             infected = np.nan
             low = np.nan
@@ -373,30 +362,29 @@ def getAgeCatSampledPrevByVillageAll(
             heavy = np.nan
             meanPOCmeasure = np.nan
         else:
-    
-            infected = np.sum(currentAgeGroupMeanEggCounts>params.POC_CCA_thresholds[0])/len(currentAgeGroupMeanEggCounts)
-     
-            medium = (
-                np.sum(
-                    (currentAgeGroupMeanEggCounts >= params.POC_CCA_thresholds[1])
-                    & (currentAgeGroupMeanEggCounts <= params.POC_CCA_thresholds[2])
-                )
-                /len(currentAgeGroupMeanEggCounts)
-            )
-    
-            heavy = np.sum(currentAgeGroupMeanEggCounts > params.POC_CCA_thresholds[2]) / len(currentAgeGroupMeanEggCounts)
-    
+            infected = np.sum(
+                currentAgeGroupMeanEggCounts > params.POC_CCA_thresholds[0]
+            ) / len(currentAgeGroupMeanEggCounts)
+
+            medium = np.sum(
+                (currentAgeGroupMeanEggCounts >= params.POC_CCA_thresholds[1])
+                & (currentAgeGroupMeanEggCounts <= params.POC_CCA_thresholds[2])
+            ) / len(currentAgeGroupMeanEggCounts)
+
+            heavy = np.sum(
+                currentAgeGroupMeanEggCounts > params.POC_CCA_thresholds[2]
+            ) / len(currentAgeGroupMeanEggCounts)
+
             low = infected - (medium + heavy)
-            meanPOCmeasure = np.round(np.mean(currentAgeGroupMeanEggCounts))    
-    
-    
+            meanPOCmeasure = np.round(np.mean(currentAgeGroupMeanEggCounts))
+
         return (
             np.array(infected),
             np.array(low),
             np.array(medium),
             np.array(heavy),
             np.array(len(currentAgeGroupMeanEggCounts)),
-            np.array(meanPOCmeasure)
+            np.array(meanPOCmeasure),
         )
 
 
@@ -408,9 +396,8 @@ def getAgeCatSampledPrevByVillageAllPOCCCA(
     Unfertilized: bool,
     nSamples: int = 2,
     villageSampleSize=100,
-    surveyType: str = 'POC-CCA'
+    surveyType: str = "POC-CCA",
 ) -> Tuple[ndarray, ndarray, ndarray, ndarray, ndarray, ndarray]:
-
     """
     This function provides sampled, age-cat worm prevalence
     for a given time point and iteration.
@@ -439,17 +426,17 @@ def getAgeCatSampledPrevByVillageAllPOCCCA(
         villageList, timeIndex, params, Unfertilized, surveyType, nSamples
     )
     ages = villageList.ages[:, timeIndex]
-    #ageGroups = (
+    # ageGroups = (
     #    np.digitize(
     #        villageList.ages[:, timeIndex], np.append(-10, np.append(ageBand, 150))
     #    )
     #    - 1
-    #)
+    # )
     currentAges = np.where(np.logical_and(ages >= ageBand[0], ages < ageBand[1]))
     currentAgeGroupMeanEggCounts = meanEggCounts[currentAges]
 
     is_empty = currentAgeGroupMeanEggCounts.size == 0
-    
+
     if is_empty:
         infected = np.nan
         low = np.nan
@@ -457,18 +444,18 @@ def getAgeCatSampledPrevByVillageAllPOCCCA(
         heavy = np.nan
         meanEggs = np.nan
     else:
-
-        infected = np.sum(currentAgeGroupMeanEggCounts>0)/len(currentAgeGroupMeanEggCounts)
- 
-        medium = (
-            np.sum(
-                (currentAgeGroupMeanEggCounts >= params.mediumThreshold)
-                & (currentAgeGroupMeanEggCounts <= params.heavyThreshold)
-            )
-            /len(currentAgeGroupMeanEggCounts)
+        infected = np.sum(currentAgeGroupMeanEggCounts > 0) / len(
+            currentAgeGroupMeanEggCounts
         )
 
-        heavy = np.sum(currentAgeGroupMeanEggCounts > params.heavyThreshold) / len(currentAgeGroupMeanEggCounts)
+        medium = np.sum(
+            (currentAgeGroupMeanEggCounts >= params.mediumThreshold)
+            & (currentAgeGroupMeanEggCounts <= params.heavyThreshold)
+        ) / len(currentAgeGroupMeanEggCounts)
+
+        heavy = np.sum(currentAgeGroupMeanEggCounts > params.heavyThreshold) / len(
+            currentAgeGroupMeanEggCounts
+        )
 
         low = infected - (medium + heavy)
         meanEggs = np.mean(currentAgeGroupMeanEggCounts)
@@ -478,9 +465,8 @@ def getAgeCatSampledPrevByVillageAllPOCCCA(
         np.array(medium),
         np.array(heavy),
         np.array(len(currentAgeGroupMeanEggCounts)),
-        np.array(meanEggs)
+        np.array(meanEggs),
     )
-
 
 
 def getAgeCatSampledPrevHeavyBurdenByVillage(
@@ -491,7 +477,7 @@ def getAgeCatSampledPrevHeavyBurdenByVillage(
     Unfertilized: bool,
     nSamples: int = 2,
     villageSampleSize: int = 100,
-    surveyType: int = 'KK2'
+    surveyType: int = "KK2",
 ) -> float:
     """
     This function provides sampled, age-cat worm prevalence
@@ -518,13 +504,10 @@ def getAgeCatSampledPrevHeavyBurdenByVillage(
     """
 
     meanEggCounts = getVillageMeanCountsByHost(
-        villageList, timeIndex, params, Unfertilized,  nSamples
+        villageList, timeIndex, params, Unfertilized, nSamples
     )
-    ageGroups = (
-        np.digitize(
-            villageList.ages[:, timeIndex], np.append(-10, np.append(ageBand, 150))
-        )
-        
+    ageGroups = np.digitize(
+        villageList.ages[:, timeIndex], np.append(-10, np.append(ageBand, 150))
     )
 
     currentAgeGroupMeanEggCounts = meanEggCounts[ageGroups == 2]
@@ -548,11 +531,10 @@ def getSampledDetectedPrevByVillageAll(
     ageBand: NDArray[np.int_],
     params: Parameters,
     Unfertilized: bool,
-    surveyType: str, 
+    surveyType: str,
     nSamples: int = 2,
     villageSampleSize: int = 100,
 ) -> List[Tuple[ndarray, ndarray, ndarray, ndarray, ndarray, ndarray]]:
-
     """
     This function provides sampled, age-cat worm prevalence
     at a given time point across all iterations.
@@ -584,7 +566,7 @@ def getSampledDetectedPrevByVillageAll(
             ageBand,
             params,
             Unfertilized,
-            surveyType, 
+            surveyType,
             nSamples,
             villageSampleSize,
         )
@@ -598,13 +580,12 @@ def getBurdens(
     numReps: int,
     ageBand: NDArray[np.int_],
     Unfertilized: bool,
-    surveyType: str, 
+    surveyType: str,
     nSamples: int = 2,
     villageSampleSize: int = 100,
 ) -> Tuple[
     NDArray[np.float_], NDArray[np.float_], NDArray[np.float_], NDArray[np.float_]
 ]:
-
     results = np.empty((0, numReps))
     low_results = np.empty((0, numReps))
     medium_results = np.empty((0, numReps))
@@ -612,15 +593,22 @@ def getBurdens(
     mean_eggs = np.empty((0, numReps))
     for t in range(len(hostData[0].timePoints)):  # loop over time points
         # calculate burdens using the same sample
-        #newrow = np.array(
+        # newrow = np.array(
         #  getSampledDetectedPrevByVillageAll(
         #        hostData, t, ageBand, params, Unfertilized, surveyType, nSamples, villageSampleSize
         #    )
-        #)
-        
+        # )
+
         newrow = np.array(
             getSampledDetectedPrevByVillageAll(
-                hostData, t, ageBand, params, Unfertilized, surveyType, 1, villageSampleSize
+                hostData,
+                t,
+                ageBand,
+                params,
+                Unfertilized,
+                surveyType,
+                1,
+                villageSampleSize,
             )
         )
         newrowinfected = newrow[:, 0]
@@ -640,7 +628,7 @@ def getBurdens(
     medium_prevalence: NDArray[np.float_] = np.sum(medium_results, axis=1) / numReps
     heavy_prevalence: NDArray[np.float_] = np.sum(heavy_results, axis=1) / numReps
     mean_egg_res: NDArray[np.float_] = np.sum(mean_eggs, axis=1) / numReps
-    
+
     return prevalence, low_prevalence, medium_prevalence, heavy_prevalence, mean_egg_res
 
 
@@ -652,9 +640,8 @@ def getSampledDetectedPrevByVillage(
     Unfertilized: bool,
     nSamples: int = 2,
     villageSampleSize: int = 100,
-    surveyType: str = 'KK2'
+    surveyType: str = "KK2",
 ) -> NDArray[np.float_]:
-
     """
     This function provides sampled, age-cat worm prevalence
     at a given time point across all iterations.
@@ -751,9 +738,8 @@ def getPrevalence(
     Unfertilized: bool,
     nSamples: int = 2,
     villageSampleSize: int = 100,
-    surveyType: str = 'KK2'
+    surveyType: str = "KK2",
 ) -> pd.DataFrame:
-
     """
     This function provides the average SAC and adult prevalence at each time point,
     where the average is calculated across all iterations.
@@ -852,8 +838,8 @@ def getPrevalence(
         }
     )
 
-    #df = df[(df["Time"] >= 50) & (df["Time"] <= 64)]
-    #df["Time"] = df["Time"] - 50
+    # df = df[(df["Time"] >= 50) & (df["Time"] <= 64)]
+    # df["Time"] = df["Time"] - 50
 
     return df
 
@@ -991,23 +977,23 @@ def getPrevalenceDALYsAll(
     data frame with SAC and adult prevalence at each time point;
     """
 
-
     df = None
     for i in range(0, int(params.maxHostAge)):  # loop over yearly age bins
-  
-        prevalence, low_prevalence, moderate_prevalence, heavy_prevalence, meanEggs = getBurdens(
+        prevalence, low_prevalence, moderate_prevalence, heavy_prevalence, meanEggs = (
+            getBurdens(
                 hostData,
                 params,
                 numReps,
                 np.array([i, i + 1]),
                 Unfertilized,
-                surveyType, 
+                surveyType,
                 nSamples=nSamples,
                 villageSampleSize=100,
             )
+        )
         age_start = i
         age_end = i + 1
-            # year = hostData[0]['timePoints']
+        # year = hostData[0]['timePoints']
 
         if i == 0:
             df = pd.DataFrame(
@@ -1018,52 +1004,51 @@ def getPrevalenceDALYsAll(
                     "intensity": np.repeat("light", len(low_prevalence)),
                     "species": np.repeat(params.species, len(low_prevalence)),
                     "measure": np.repeat("prevalence", len(low_prevalence)),
-                    OUTPUT_COLUMN_NAME: np.round(low_prevalence,4),
+                    OUTPUT_COLUMN_NAME: np.round(low_prevalence, 4),
                 }
             )
 
         else:
             assert df is not None
             newrows = pd.DataFrame(
-                    {
-                        "Time": hostData[0].timePoints,
-                        "age_start": np.repeat(age_start, len(low_prevalence)),
-                        "age_end": np.repeat(age_end, len(low_prevalence)),
-                        "intensity": np.repeat("light", len(low_prevalence)),
-                        "species": np.repeat(params.species, len(low_prevalence)),
-                        "measure": np.repeat("prevalence", len(low_prevalence)),
-                        OUTPUT_COLUMN_NAME: np.round(low_prevalence,4),
-                    }
-                )
-            df = pd.concat([df, newrows], ignore_index = True)
-            
-
-        newrows = pd.DataFrame(
                 {
                     "Time": hostData[0].timePoints,
                     "age_start": np.repeat(age_start, len(low_prevalence)),
                     "age_end": np.repeat(age_end, len(low_prevalence)),
-                    "intensity": np.repeat("moderate", len(low_prevalence)),
+                    "intensity": np.repeat("light", len(low_prevalence)),
                     "species": np.repeat(params.species, len(low_prevalence)),
                     "measure": np.repeat("prevalence", len(low_prevalence)),
-                    OUTPUT_COLUMN_NAME: np.round(moderate_prevalence,4),
+                    OUTPUT_COLUMN_NAME: np.round(low_prevalence, 4),
                 }
             )
-        df = pd.concat([df, newrows], ignore_index = True)
+            df = pd.concat([df, newrows], ignore_index=True)
 
         newrows = pd.DataFrame(
-                {
-                    "Time": hostData[0].timePoints,
-                    "age_start": np.repeat(age_start, len(low_prevalence)),
-                    "age_end": np.repeat(age_end, len(low_prevalence)),
-                    "intensity": np.repeat("heavy", len(low_prevalence)),
-                    "species": np.repeat(params.species, len(low_prevalence)),
-                    "measure": np.repeat("prevalence", len(low_prevalence)),
-                    OUTPUT_COLUMN_NAME: np.round(heavy_prevalence,4),
-                }
-            )
-        df = pd.concat([df, newrows], ignore_index = True)
-        
+            {
+                "Time": hostData[0].timePoints,
+                "age_start": np.repeat(age_start, len(low_prevalence)),
+                "age_end": np.repeat(age_end, len(low_prevalence)),
+                "intensity": np.repeat("moderate", len(low_prevalence)),
+                "species": np.repeat(params.species, len(low_prevalence)),
+                "measure": np.repeat("prevalence", len(low_prevalence)),
+                OUTPUT_COLUMN_NAME: np.round(moderate_prevalence, 4),
+            }
+        )
+        df = pd.concat([df, newrows], ignore_index=True)
+
+        newrows = pd.DataFrame(
+            {
+                "Time": hostData[0].timePoints,
+                "age_start": np.repeat(age_start, len(low_prevalence)),
+                "age_end": np.repeat(age_end, len(low_prevalence)),
+                "intensity": np.repeat("heavy", len(low_prevalence)),
+                "species": np.repeat(params.species, len(low_prevalence)),
+                "measure": np.repeat("prevalence", len(low_prevalence)),
+                OUTPUT_COLUMN_NAME: np.round(heavy_prevalence, 4),
+            }
+        )
+        df = pd.concat([df, newrows], ignore_index=True)
+
         # newrows = pd.DataFrame(
         #         {
         #             "Time": hostData[0].timePoints,
@@ -1077,41 +1062,36 @@ def getPrevalenceDALYsAll(
         #     )
         # df = pd.concat([df, newrows], ignore_index = True)
 
-     
-
     return df
 
 
 def getIncidence(results: List[List[Result]], params: Parameters) -> pd.DataFrame:
-
     for i in range(len(results[0])):
         d = results[0][i]
         value, _ = np.histogram(
-                d.incidenceAges,
-                bins=np.arange(0, params.maxHostAge + 1),
-            )
-        
+            d.incidenceAges,
+            bins=np.arange(0, params.maxHostAge + 1),
+        )
+
         newrows = pd.DataFrame(
-                {
-                    "Time": np.repeat(d.time, len(value)),
-                    "age_start": range(int(params.maxHostAge)),
-                    "age_end": range(1, 1 + int(params.maxHostAge)),
-                    "intensity": np.repeat("None", len(value)),
-                    "species": np.repeat(params.species, len(value)),
-                    "measure": np.repeat("Incidence", len(value)),
-                    OUTPUT_COLUMN_NAME: value,
-                }
-            )
+            {
+                "Time": np.repeat(d.time, len(value)),
+                "age_start": range(int(params.maxHostAge)),
+                "age_end": range(1, 1 + int(params.maxHostAge)),
+                "intensity": np.repeat("None", len(value)),
+                "species": np.repeat(params.species, len(value)),
+                "measure": np.repeat("Incidence", len(value)),
+                OUTPUT_COLUMN_NAME: value,
+            }
+        )
         if i == 0:
             incidence = newrows
         else:
             assert incidence is not None
-            
-            incidence = pd.concat([incidence, newrows], ignore_index = True)
+
+            incidence = pd.concat([incidence, newrows], ignore_index=True)
 
     return incidence
-
-
 
 
 def getPrevalenceWholePop(
@@ -1145,32 +1125,29 @@ def getPrevalenceWholePop(
     data frame with SAC and adult prevalence at each time point;
     """
 
-
     df = None
     prevalence, _, _, _, _ = getBurdens(
-                hostData,
-                params,
-                numReps,
-                np.array([0, int(params.maxHostAge) + 1]),
-                Unfertilized,
-                surveyType, 
-                nSamples=nSamples,
-                villageSampleSize=100,
-            )
-
+        hostData,
+        params,
+        numReps,
+        np.array([0, int(params.maxHostAge) + 1]),
+        Unfertilized,
+        surveyType,
+        nSamples=nSamples,
+        villageSampleSize=100,
+    )
 
     df = pd.DataFrame(
-                {
-                    "Time": hostData[0].timePoints,
-                    "age_start": np.repeat("None", len(prevalence)),
-                    "age_end": np.repeat("None", len(prevalence)),
-                    "intensity": np.repeat("All", len(prevalence)),
-                    "species": np.repeat(params.species, len(prevalence)),
-                    "measure": np.repeat("Estimated population prevalence", len(prevalence)),
-                    OUTPUT_COLUMN_NAME: np.round(prevalence,4),
-                }
-            )
-     
+        {
+            "Time": hostData[0].timePoints,
+            "age_start": np.repeat("None", len(prevalence)),
+            "age_end": np.repeat("None", len(prevalence)),
+            "intensity": np.repeat("All", len(prevalence)),
+            "species": np.repeat(params.species, len(prevalence)),
+            "measure": np.repeat("Estimated population prevalence", len(prevalence)),
+            OUTPUT_COLUMN_NAME: np.round(prevalence, 4),
+        }
+    )
 
     return df
 
@@ -1188,29 +1165,27 @@ def outputNumberInAgeGroup(
         for j in range(int(params.maxHostAge)):
             age_counts.append(ages1.count(j))
         newrows = pd.DataFrame(
-                {
-                    "Time": np.repeat(d.time, len(age_counts)),
-                    "age_start": range(int(params.maxHostAge)),
-                    "age_end": range(1, 1 + int(params.maxHostAge)),
-                    "intensity": np.repeat("None", len(age_counts)),
-                    "species": np.repeat(params.species, len(age_counts)),
-                    "measure": np.repeat("number", len(age_counts)),
-                    OUTPUT_COLUMN_NAME: age_counts,
-                }
-            )
+            {
+                "Time": np.repeat(d.time, len(age_counts)),
+                "age_start": range(int(params.maxHostAge)),
+                "age_end": range(1, 1 + int(params.maxHostAge)),
+                "intensity": np.repeat("None", len(age_counts)),
+                "species": np.repeat(params.species, len(age_counts)),
+                "measure": np.repeat("number", len(age_counts)),
+                OUTPUT_COLUMN_NAME: age_counts,
+            }
+        )
         if i == 0:
             numEachAgeGroup = newrows
         else:
             assert numEachAgeGroup is not None
-            
-            numEachAgeGroup = pd.concat([numEachAgeGroup, newrows], ignore_index = True)
+
+            numEachAgeGroup = pd.concat([numEachAgeGroup, newrows], ignore_index=True)
 
     return numEachAgeGroup
 
 
-def outputNumberSurveyedAgeGroup(
-    SD: SDEquilibrium, params: Parameters
-) -> pd.DataFrame:
+def outputNumberSurveyedAgeGroup(SD: SDEquilibrium, params: Parameters) -> pd.DataFrame:
     assert params.maxHostAge is not None
     d = None
     count = 0
@@ -1218,41 +1193,39 @@ def outputNumberSurveyedAgeGroup(
         t = math.floor(float(key.split(",")[0]))
         measure = str(key.split(",")[1])
         newrows = pd.DataFrame(
-                {
-                    "Time": np.repeat(t, len(value)),
-                    "age_start": range(int(params.maxHostAge)),
-                    "age_end": range(1, 1 + int(params.maxHostAge)),
-                    "intensity": np.repeat("None", len(value)),
-                    "species": np.repeat(params.species, len(value)),
-                    "measure": np.repeat(measure, len(value)),
-                    OUTPUT_COLUMN_NAME: value,
-                }
-            )
+            {
+                "Time": np.repeat(t, len(value)),
+                "age_start": range(int(params.maxHostAge)),
+                "age_end": range(1, 1 + int(params.maxHostAge)),
+                "intensity": np.repeat("None", len(value)),
+                "species": np.repeat(params.species, len(value)),
+                "measure": np.repeat(measure, len(value)),
+                OUTPUT_COLUMN_NAME: value,
+            }
+        )
         if count == 0:
             count = 1
             d = newrows
         else:
             assert d is not None
-            d = pd.concat([d, newrows], ignore_index = True)
-        
-        v2 = value/SD.n_surveys_population[key]
-        newrows2 = pd.DataFrame(
-                {
-                    "Time": np.repeat(t, len(value)),
-                    "age_start": range(int(params.maxHostAge)),
-                    "age_end": range(1, 1 + int(params.maxHostAge)),
-                    "intensity": np.repeat("None", len(value)),
-                    "species": np.repeat(params.species, len(value)),
-                    "measure": np.repeat("survey coverage", len(value)),
-                    OUTPUT_COLUMN_NAME: v2,
-                }
-            )
-        
-        d = pd.concat([d, newrows2], ignore_index = True)
+            d = pd.concat([d, newrows], ignore_index=True)
 
+        v2 = value / SD.n_surveys_population[key]
+        newrows2 = pd.DataFrame(
+            {
+                "Time": np.repeat(t, len(value)),
+                "age_start": range(int(params.maxHostAge)),
+                "age_end": range(1, 1 + int(params.maxHostAge)),
+                "intensity": np.repeat("None", len(value)),
+                "species": np.repeat(params.species, len(value)),
+                "measure": np.repeat("survey coverage", len(value)),
+                OUTPUT_COLUMN_NAME: v2,
+            }
+        )
+
+        d = pd.concat([d, newrows2], ignore_index=True)
 
     return d
-
 
 
 def outputNumberTreatmentAgeGroup(
@@ -1265,37 +1238,37 @@ def outputNumberTreatmentAgeGroup(
         t = math.floor(float(key.split(",")[0]))
         measure = str(key.split(",")[1])
         newrows = pd.DataFrame(
-                {
-                    "Time": np.repeat(t, len(value)),
-                    "age_start": range(int(params.maxHostAge)),
-                    "age_end": range(1, 1 + int(params.maxHostAge)),
-                    "intensity": np.repeat("None", len(value)),
-                    "species": np.repeat(params.species, len(value)),
-                    "measure": np.repeat(measure, len(value)),
-                    OUTPUT_COLUMN_NAME: value,
-                }
-            )
+            {
+                "Time": np.repeat(t, len(value)),
+                "age_start": range(int(params.maxHostAge)),
+                "age_end": range(1, 1 + int(params.maxHostAge)),
+                "intensity": np.repeat("None", len(value)),
+                "species": np.repeat(params.species, len(value)),
+                "measure": np.repeat(measure, len(value)),
+                OUTPUT_COLUMN_NAME: value,
+            }
+        )
         if count == 0:
             count = 1
             d = newrows
         else:
             assert d is not None
-            d = pd.concat([d, newrows], ignore_index = True)
-        
-        v2 = value/SD.n_treatments_population[key]
+            d = pd.concat([d, newrows], ignore_index=True)
+
+        v2 = value / SD.n_treatments_population[key]
         m1 = measure + " coverage"
         newrows2 = pd.DataFrame(
-                {
-                    "Time": np.repeat(t, len(value)),
-                    "age_start": range(int(params.maxHostAge)),
-                    "age_end": range(1, 1 + int(params.maxHostAge)),
-                    "intensity": np.repeat("None", len(value)),
-                    "species": np.repeat(params.species, len(value)),
-                    "measure": np.repeat(m1, len(value)),
-                    OUTPUT_COLUMN_NAME: v2,
-                }
-            )
-        
-        d = pd.concat([d, newrows2], ignore_index = True)
+            {
+                "Time": np.repeat(t, len(value)),
+                "age_start": range(int(params.maxHostAge)),
+                "age_end": range(1, 1 + int(params.maxHostAge)),
+                "intensity": np.repeat("None", len(value)),
+                "species": np.repeat(params.species, len(value)),
+                "measure": np.repeat(m1, len(value)),
+                OUTPUT_COLUMN_NAME: v2,
+            }
+        )
+
+        d = pd.concat([d, newrows2], ignore_index=True)
 
     return d

--- a/sch_simulation/helsim_FUNC_KK/utils.py
+++ b/sch_simulation/helsim_FUNC_KK/utils.py
@@ -14,13 +14,12 @@ np.seterr(divide="ignore")
 def getSetOfEggCounts(
     total: NDArray[np.int_],
     female: NDArray[np.int_],
-    vaccState:NDArray[np.int_],
+    vaccState: NDArray[np.int_],
     params: Parameters,
     Unfertilized: bool,
     nSamples: int = 2,
-    surveyType: str = 'KK2'
+    surveyType: str = "KK2",
 ) -> NDArray[np.int_]:
-
     """
     This function returns a set of readings of egg counts from a vector of individuals,
     according to their reproductive biology.
@@ -39,49 +38,50 @@ def getSetOfEggCounts(
     random set of egg count readings from a single sample;
     """
 
-    
     # if Unfertilized:
 
     #     meanCount = female * params.lambda_egg * params.z**female * params.v2[vaccState]
 
     # else:
     if params.reproFuncName == "epgFertility" and params.SR:
-            productivefemaleworms = np.where(
-                total == female, 0, female
-            )
+        productivefemaleworms = np.where(total == female, 0, female)
 
     elif params.reproFuncName == "epgFertility" and not params.SR:
-            productivefemaleworms = female
+        productivefemaleworms = female
 
-        # monogamous reproduction; only pairs of worms produce eggs
+    # monogamous reproduction; only pairs of worms produce eggs
     elif params.reproFuncName == "epgMonog":
-            productivefemaleworms = np.minimum(
-                total - female, female
-            )
-        #eggProducers = np.where(total == female, 0, female)
-        #meanCount = eggProducers * params.lambda_egg * params.z**eggProducers * params.v2[vaccState]
-    meanCount = productivefemaleworms * params.lambda_egg * params.z**productivefemaleworms * params.v2[vaccState]
-    eggs = np.random.negative_binomial(size=len(meanCount), 
-                                           p=params.k_epg / (meanCount + params.k_epg), 
-                                           n=params.k_epg)
-        
+        productivefemaleworms = np.minimum(total - female, female)
+    # eggProducers = np.where(total == female, 0, female)
+    # meanCount = eggProducers * params.lambda_egg * params.z**eggProducers * params.v2[vaccState]
+    meanCount = (
+        productivefemaleworms
+        * params.lambda_egg
+        * params.z**productivefemaleworms
+        * params.v2[vaccState]
+    )
+    eggs = np.random.negative_binomial(
+        size=len(meanCount), p=params.k_epg / (meanCount + params.k_epg), n=params.k_epg
+    )
+
     if surveyType == "KK2":
-        eggs +=  np.random.negative_binomial(size=len(meanCount), 
-                                             p=params.k_epg / (meanCount + params.k_epg), 
-                                             n=params.k_epg)
+        eggs += np.random.negative_binomial(
+            size=len(meanCount),
+            p=params.k_epg / (meanCount + params.k_epg),
+            n=params.k_epg,
+        )
     return eggs
-        
-        
+
+
 def getSetOfEggCountsv2(
     total: NDArray[np.int_],
     female: NDArray[np.int_],
-    vaccState:NDArray[np.int_],
+    vaccState: NDArray[np.int_],
     params: Parameters,
     Unfertilized: bool,
     nSamples: int = 2,
-    surveyType: str = 'KK2'
+    surveyType: str = "KK2",
 ) -> NDArray[np.int_]:
-
     """
     This function returns a set of readings of egg counts from a vector of individuals,
     according to their reproductive biology.
@@ -100,58 +100,61 @@ def getSetOfEggCountsv2(
     random set of egg count readings from a single sample;
     """
 
-    
     # if Unfertilized:
 
     #     meanCount = female * params.lambda_egg * params.z**female * params.v2[vaccState]
 
     # else:
     if params.reproFuncName == "epgFertility" and params.SR:
-            productivefemaleworms = np.where(
-                total == female, 0, female
-            )
+        productivefemaleworms = np.where(total == female, 0, female)
 
     elif params.reproFuncName == "epgFertility" and not params.SR:
-            productivefemaleworms = female
+        productivefemaleworms = female
 
-        # monogamous reproduction; only pairs of worms produce eggs
+    # monogamous reproduction; only pairs of worms produce eggs
     elif params.reproFuncName == "epgMonog":
-            productivefemaleworms = np.minimum(
-                total - female, female
-            )
-        #eggProducers = np.where(total == female, 0, female)
-        #meanCount = eggProducers * params.lambda_egg * params.z**eggProducers * params.v2[vaccState]
-    meanCount = productivefemaleworms * params.lambda_egg * params.z**productivefemaleworms * params.v2[vaccState]
-        
+        productivefemaleworms = np.minimum(total - female, female)
+    # eggProducers = np.where(total == female, 0, female)
+    # meanCount = eggProducers * params.lambda_egg * params.z**eggProducers * params.v2[vaccState]
+    meanCount = (
+        productivefemaleworms
+        * params.lambda_egg
+        * params.z**productivefemaleworms
+        * params.v2[vaccState]
+    )
+
     if surveyType == "KK1":
         # eggs = np.random.negative_binomial(size=len(meanCount), p=params.k_epg / (meanCount + params.k_epg), n=params.k_epg)
         # for i in range(nSamples):
         #     eggs +=  np.random.negative_binomial(
         #         size=len(meanCount), p=params.k_epg / (meanCount + params.k_epg), n=params.k_epg
         #         )
-        mu_id = np.random.gamma(params.k_within, 
-                                scale= meanCount/ params.k_within, 
-                                size=len(female))
-        mu_ids = np.random.gamma(params.k_slide * params.weight_sample / 0.025,
-                                  scale= mu_id/params.k_slide, 
-                                  size=len(female))
+        mu_id = np.random.gamma(
+            params.k_within, scale=meanCount / params.k_within, size=len(female)
+        )
+        mu_ids = np.random.gamma(
+            params.k_slide * params.weight_sample / 0.025,
+            scale=mu_id / params.k_slide,
+            size=len(female),
+        )
         count_ids = np.zeros(len(mu_ids))
-        
+
         count_ids += np.random.poisson(mu_ids)
         return count_ids / params.weight_sample
         # return eggs
     if surveyType == "KK2":
-        mu_id = np.random.gamma(params.k_within, 
-                                scale= meanCount/ params.k_within, 
-                                size=len(female))
-        mu_ids = np.random.gamma(params.k_slide * params.weight_sample / 0.025,
-                                  scale= mu_id/params.k_slide, 
-                                  size=len(female))
+        mu_id = np.random.gamma(
+            params.k_within, scale=meanCount / params.k_within, size=len(female)
+        )
+        mu_ids = np.random.gamma(
+            params.k_slide * params.weight_sample / 0.025,
+            scale=mu_id / params.k_slide,
+            size=len(female),
+        )
         count_ids = np.zeros(len(mu_ids))
         for i in range(nSamples):
             count_ids += np.random.poisson(mu_ids)
-            
-        
+
         return count_ids / params.weight_sample
         # eggs = np.random.negative_binomial(size=len(meanCount), p=params.k_epg / (meanCount + params.k_epg), n=params.k_epg)
         # for i in range(nSamples):
@@ -160,15 +163,15 @@ def getSetOfEggCountsv2(
         #         )
         # return eggs
 
+
 def KKsampleGammaGammaPois(
     total: NDArray[np.int_],
     female: NDArray[np.int_],
-    vaccState:NDArray[np.int_],
+    vaccState: NDArray[np.int_],
     params: Parameters,
-    Unfertilized: bool ,
-    nSamples: int
+    Unfertilized: bool,
+    nSamples: int,
 ) -> NDArray[np.int_]:
-
     """
     This function returns a set of readings of egg counts from a vector of individuals,
     according to their reproductive biology.
@@ -187,49 +190,44 @@ def KKsampleGammaGammaPois(
     random set of egg count readings from a single sample;
     """
 
-    
     # if Unfertilized:
 
     #     meanCount = female * params.lambda_egg * params.z**female * params.v2[vaccState]
 
     # else:
     if params.reproFuncName == "epgFertility" and params.SR:
-            productivefemaleworms = np.where(
-                total == female, 0, female
-            )
+        productivefemaleworms = np.where(total == female, 0, female)
 
     elif params.reproFuncName == "epgFertility" and not params.SR:
-            productivefemaleworms = female
+        productivefemaleworms = female
 
-        # monogamous reproduction; only pairs of worms produce eggs
+    # monogamous reproduction; only pairs of worms produce eggs
     elif params.reproFuncName == "epgMonog":
-            productivefemaleworms = np.minimum(
-                total - female, female
-            )
-        #eggProducers = np.where(total == female, 0, female)
-        #meanCount = eggProducers * params.lambda_egg * params.z**eggProducers * params.v2[vaccState]
-    meanCount = productivefemaleworms * params.lambda_egg * params.z**productivefemaleworms * params.v2[vaccState]
-        
-        
-    mu_id = np.random.gamma(params.k_within, 
-                            scale= meanCount/ params.k_within, 
-                            size=len(female))
-    mu_ids = np.random.gamma(params.k_slide * params.weight_sample / 0.025,
-                             scale= mu_id/params.k_slide, 
-                             size=len(female))
+        productivefemaleworms = np.minimum(total - female, female)
+    # eggProducers = np.where(total == female, 0, female)
+    # meanCount = eggProducers * params.lambda_egg * params.z**eggProducers * params.v2[vaccState]
+    meanCount = (
+        productivefemaleworms
+        * params.lambda_egg
+        * params.z**productivefemaleworms
+        * params.v2[vaccState]
+    )
+
+    mu_id = np.random.gamma(
+        params.k_within, scale=meanCount / params.k_within, size=len(female)
+    )
+    mu_ids = np.random.gamma(
+        params.k_slide * params.weight_sample / 0.025,
+        scale=mu_id / params.k_slide,
+        size=len(female),
+    )
     count_ids = 0
     for i in range(nSamples):
         count_ids += np.random.poisson(mu_ids)
     return count_ids / params.weight_sample
-    
-    
-    
-    
-def POC_CCA_test(
-    total: NDArray[np.int_],
-    params: Parameters
-) -> NDArray[np.int_]:
 
+
+def POC_CCA_test(total: NDArray[np.int_], params: Parameters) -> NDArray[np.int_]:
     """
     This function returns a set of readings of egg counts from a vector of individuals,
     according to their reproductive biology.
@@ -244,21 +242,19 @@ def POC_CCA_test(
     positive of negative for each person;
     """
 
-    antigen_test = 1*(np.random.uniform(size = len(total)) < (1 - np.power((1-params.testSensitivity), total)))
+    antigen_test = 1 * (
+        np.random.uniform(size=len(total))
+        < (1 - np.power((1 - params.testSensitivity), total))
+    )
     x = np.where(total == 0)
-    antigen_test[x[0]] = 1*np.random.uniform(size = len(x[0])) > params.testSpecificity
-    
+    antigen_test[x[0]] = 1 * np.random.uniform(size=len(x[0])) > params.testSpecificity
+
     return antigen_test
-    
 
 
-    
 def PCR_test(
-    total: NDArray[np.int_],
-    female : NDArray[np.int_],
-    params: Parameters
+    total: NDArray[np.int_], female: NDArray[np.int_], params: Parameters
 ) -> NDArray[np.int_]:
-
     """
     This function returns a set of readings of egg counts from a vector of individuals,
     according to their reproductive biology.
@@ -275,19 +271,19 @@ def PCR_test(
     positive or negative for each person;
     """
 
-    worm_pairs = np.minimum(
-        total - female, female
+    worm_pairs = np.minimum(total - female, female)
+
+    antigen_test = 1 * (
+        np.random.uniform(size=len(worm_pairs))
+        < (1 - np.power((1 - params.testSensitivity), worm_pairs))
     )
-    
-    antigen_test = 1*(np.random.uniform(size = len(worm_pairs)) < (1 - np.power((1-params.testSensitivity),worm_pairs)))
     x = np.where(worm_pairs == 0)
-    antigen_test[x[0]] = 1*np.random.uniform(size = len(x[0])) > params.testSpecificity
-    
+    antigen_test[x[0]] = 1 * np.random.uniform(size=len(x[0])) > params.testSpecificity
+
     return antigen_test
 
 
 def calcRates(params: Parameters, SD: SDEquilibrium) -> ndarray:
-
     """
     This function calculates the event rates; the events are
     new worms, worms death and vaccination recovery rates.
@@ -311,7 +307,6 @@ def calcRates(params: Parameters, SD: SDEquilibrium) -> ndarray:
 
 
 def calcRates2(params: Parameters, SD: SDEquilibrium) -> NDArray[np.float_]:
-
     """
     This function calculates the event rates; the events are
     new worms, worms death and vaccination recovery rates.
@@ -336,7 +331,6 @@ def calcRates2(params: Parameters, SD: SDEquilibrium) -> NDArray[np.float_]:
 
 
 def getLifeSpans(nSpans: int, params: Parameters) -> float:
-
     """
     This function draws the lifespans from the population survival curve.
     Parameters
@@ -363,7 +357,6 @@ def getLifeSpans(nSpans: int, params: Parameters) -> float:
 
 
 def getPsi(params: Parameters) -> float:
-
     """
     This function calculates the psi parameter.
     Parameters

--- a/sch_simulation/helsim_RUN_KK.py
+++ b/sch_simulation/helsim_RUN_KK.py
@@ -424,9 +424,8 @@ def doRealizationSurveyCoveragePickle(
                 # get approximate prevalence of the population
                 prev = len(np.where(eggCounts > 0)[0])/len(eggCounts)
                 if len(results) > 0:
-                    l = len(results)
                     # get ids of people who had 0 eggs last time step
-                    previousZeros = results[l-1].id[np.where(results[l-1].eggCounts == 0)]
+                    previousZeros = results[-1].id[np.where(results[-1].eggCounts == 0)]
                     # get ids of people who have non-zero eggs this time step
                     nonZeros = SD.id[np.where(eggCounts > 0)]
                     # get the intersection of these ids, as this is the incidence in this timestep
@@ -1034,12 +1033,11 @@ def multiple_simulations(
         contactAgeGroupIndices = []
         treatmentAgeGroupIndices = []
         for k in range(len(chosenIndivs)):
-            l = chosenIndivs[k]
-            si.append(simData.si[l])
-            wormsT.append(simData.worms.total[l])
-            wormsF.append(simData.worms.female[l])
-            contactAgeGroupIndices.append(simData.contactAgeGroupIndices[l])
-            treatmentAgeGroupIndices.append(simData.treatmentAgeGroupIndices[l])
+            si.append(simData.si[chosenIndivs[k]])
+            wormsT.append(simData.worms.total[chosenIndivs[k]])
+            wormsF.append(simData.worms.female[chosenIndivs[k]])
+            contactAgeGroupIndices.append(simData.contactAgeGroupIndices[chosenIndivs[k]])
+            treatmentAgeGroupIndices.append(simData.treatmentAgeGroupIndices[chosenIndivs[k]])
         demography = helsim_structures.Demography(
         birthDate=np.array(birthDate),
         deathDate=np.array(deathDate),

--- a/sch_simulation/helsim_RUN_KK.py
+++ b/sch_simulation/helsim_RUN_KK.py
@@ -1,4 +1,3 @@
-
 import copy
 import math
 import multiprocessing
@@ -8,7 +7,6 @@ from typing import List, Optional
 
 import numpy as np
 import pandas as pd
-from joblib import Parallel, delayed
 
 from .helsim_FUNC_KK import (
     configuration,
@@ -16,7 +14,7 @@ from .helsim_FUNC_KK import (
     file_parsing,
     helsim_structures,
     results_processing,
-    utils
+    utils,
 )
 
 num_cores = multiprocessing.cpu_count()
@@ -65,8 +63,8 @@ def doRealization(params, i, mult):
     results: List[helsim_structures.Result]
         list with simulation results;
     """
-    #np.random.seed(i) 
-    #random.seed(i)
+    # np.random.seed(i)
+    # random.seed(i)
     params.equiData = configuration.getEquilibrium(params)
     # setup simulation data
     simData = configuration.setupSD(params)
@@ -119,26 +117,22 @@ def doRealization(params, i, mult):
         )
     )
 
-    results: List[helsim_structures.Result] = []  # initialise empty list to store results
+    results: List[
+        helsim_structures.Result
+    ] = []  # initialise empty list to store results
     multiplier = math.floor(
         params.N / 50
     )  # This appears to be the optimal value for all tests I've run - more or less than this takes longer!
-    print_t_interval = 0.5
-    print_t = 0
     # run stochastic algorithm
     while t < maxTime:
-       # if (t * 1000 % 10) == 0:
-        # if t > print_t:
-        #     print_t += print_t_interval
-        #     print(t)
         rates = utils.calcRates2(params, simData)
         sumRates = np.sum(rates)
         cumsumRates = np.cumsum(rates)
-        new_multiplier = min(math.ceil(min((1/365) * sumRates, multiplier)), mult)
-        #new_multiplier = math.floor(min((1/365) * sumRates, multiplier))
-        #print(new_multiplier)
+        new_multiplier = min(math.ceil(min((1 / 365) * sumRates, multiplier)), mult)
+        # new_multiplier = math.floor(min((1/365) * sumRates, multiplier))
+        # print(new_multiplier)
         new_multiplier = max(new_multiplier, 1)
-        #new_multiplier = 5
+        # new_multiplier = 5
         # if the rate is such that nothing's likely to happen in the next 10,000 years,
         # just fix the next time step to 10,000
         if sumRates < 1e-4:
@@ -146,12 +140,12 @@ def doRealization(params, i, mult):
 
         else:
             dt = random.expovariate(lambd=sumRates) * new_multiplier
-        
+
         if mult > 1:
             if t + dt >= nextStep:
                 small_multiplier = np.array(list(range(new_multiplier, 0, -1)))
-                dt1 = dt * small_multiplier/new_multiplier
-                x = np.where((t+dt1) < nextStep)[0]
+                dt1 = dt * small_multiplier / new_multiplier
+                x = np.where((t + dt1) < nextStep)[0]
                 if len(x) > 0:
                     x = x[0]
                     sm = small_multiplier[x]
@@ -161,14 +155,15 @@ def doRealization(params, i, mult):
                     sm = 1
                     dt = dt * sm / new_multiplier
                     new_multiplier = sm
-                    
+
         if t + dt < nextStep:
             t += dt
-            simData = events.doEvent2(sumRates, cumsumRates, params, simData, new_multiplier)
-            #simData = events.doFreeLive(params, simData, dt)
-            #freeliveTime = t
+            simData = events.doEvent2(
+                sumRates, cumsumRates, params, simData, new_multiplier
+            )
+            # simData = events.doFreeLive(params, simData, dt)
+            # freeliveTime = t
         else:
-
             simData = events.doFreeLive(params, simData, nextStep - freeliveTime)
 
             t = nextStep
@@ -177,14 +172,12 @@ def doRealization(params, i, mult):
 
             # ageing and death
             if timeBarrier >= nextAgeTime:
-
                 simData = events.doDeath(params, simData, t)
 
                 nextAgeTime += ageingInt
 
             # chemotherapy
             if timeBarrier >= nextChemoTime1:
-
                 simData = events.doDeath(params, simData, t)
                 simData = events.doChemo(params, simData, t, params.coverage1)
 
@@ -193,7 +186,6 @@ def doRealization(params, i, mult):
                 nextChemoTime1 = currentchemoTiming1[nextChemoIndex1]
 
             if timeBarrier >= nextChemoTime2:
-
                 simData = events.doDeath(params, simData, t)
                 simData = events.doChemo(params, simData, t, params.coverage2)
 
@@ -202,7 +194,6 @@ def doRealization(params, i, mult):
                 nextChemoTime2 = currentchemoTiming2[nextChemoIndex2]
 
             if timeBarrier >= nextVaccineTime:
-
                 simData = events.doDeath(params, simData, t)
                 simData = events.doVaccine(params, simData, t, params.VaccCoverage)
                 currentVaccineTimings[nextVaccineIndex] = maxTime + 10
@@ -211,10 +202,17 @@ def doRealization(params, i, mult):
 
             if timeBarrier >= nextOutTime:
                 SD = copy.deepcopy(simData)
-                eggCounts = utils.getSetOfEggCounts(SD.worms.total, SD.worms.female, SD.sv, params,  
-                                              params.Unfertilized, params.nSamples, "KK2")
+                eggCounts = utils.getSetOfEggCounts(
+                    SD.worms.total,
+                    SD.worms.female,
+                    SD.sv,
+                    params,
+                    params.Unfertilized,
+                    params.nSamples,
+                    "KK2",
+                )
                 # get approximate prevalence of the population
-                prev = len(np.where(eggCounts > 0)[0])/len(eggCounts)
+                prev = len(np.where(eggCounts > 0)[0]) / len(eggCounts)
                 results.append(
                     helsim_structures.Result(
                         iteration=1,
@@ -227,7 +225,9 @@ def doRealization(params, i, mult):
                         compliers=copy.deepcopy(simData.compliers),
                         si=copy.deepcopy(simData.si),
                         sv=copy.deepcopy(simData.sv),
-                        contactAgeGroupIndices=copy.deepcopy(simData.contactAgeGroupIndices),
+                        contactAgeGroupIndices=copy.deepcopy(
+                            simData.contactAgeGroupIndices
+                        ),
                         nVacc=0,
                         nChemo1=0,
                         nChemo2=0,
@@ -236,9 +236,9 @@ def doRealization(params, i, mult):
                         elimination=0,
                         propChemo1=0,
                         propChemo2=0,
-                        propVacc = 0,
-                        id = simData.id,
-                        prevalence = prev
+                        propVacc=0,
+                        id=simData.id,
+                        prevalence=prev,
                     )
                 )
                 outTimes[nextOutIndex] = maxTime + 10
@@ -264,11 +264,11 @@ def doRealization(params, i, mult):
     return results
 
 
-
-
-
 def doRealizationSurveyCoveragePickle(
-    params: helsim_structures.Parameters, surveyType: str,  simData: Optional[helsim_structures.SDEquilibrium] = None, mult: int = 5
+    params: helsim_structures.Parameters,
+    surveyType: str,
+    simData: Optional[helsim_structures.SDEquilibrium] = None,
+    mult: int = 5,
 ) -> List[helsim_structures.Result]:
     """
     This function generates a single simulation path.
@@ -308,8 +308,7 @@ def doRealizationSurveyCoveragePickle(
     ageingInt = 1 / 52
     nextAgeTime = 1 / 52
     maxStep = 1 / 52
-    
-  
+
     (
         chemoTiming,
         VaccTiming,
@@ -324,16 +323,16 @@ def doRealizationSurveyCoveragePickle(
     ) = file_parsing.nextMDAVaccInfo(params)
 
     # next event
-    
+
     nextStep = min(
         float(nextOutTime),
         float(t + maxStep),
         float(nextChemoTime),
         float(nextAgeTime),
         float(nextVaccTime),
-        float(nextVecControlTime)
+        float(nextVecControlTime),
     )
-    
+
     propChemo1 = []
     propChemo2 = []
     propVacc = []
@@ -346,28 +345,19 @@ def doRealizationSurveyCoveragePickle(
     surveyPass = 0
     tSurvey = maxTime + 10
     results = []  # initialise empty list to store results
-    print_t_interval = 0.5
-    print_t = 0
-  
-    #tSurvey = 0.9
-      
 
     # run stochastic algorithm
     multiplier = math.floor(
         params.N / 50
     )  # This appears to be the optimal value for all tests I've run - more or less than this takes longer!
     while t < maxTime:
-
-        # if t > print_t:
-        #     print_t += print_t_interval
-        #     print(t)
         rates = utils.calcRates2(params, simData)
         sumRates = np.sum(rates)
         cumsumRates = np.cumsum(rates)
-        
-        new_multiplier = min(math.ceil(min((1/365) * sumRates, multiplier)), mult)
+
+        new_multiplier = min(math.ceil(min((1 / 365) * sumRates, multiplier)), mult)
         new_multiplier = max(new_multiplier, 1)
-        
+
         # if the rate is such that nothing's likely to happen in the next 10,000 years,
         # just fix the next time step to 10,000
 
@@ -376,12 +366,12 @@ def doRealizationSurveyCoveragePickle(
 
         else:
             dt = random.expovariate(lambd=sumRates) * new_multiplier
-        
+
         if mult > 1:
             if t + dt >= nextStep:
                 small_multiplier = np.array(list(range(new_multiplier, 0, -1)))
-                dt1 = dt * small_multiplier/new_multiplier
-                x = np.where((t+dt1) < nextStep)[0]
+                dt1 = dt * small_multiplier / new_multiplier
+                x = np.where((t + dt1) < nextStep)[0]
                 if len(x) > 0:
                     x = x[0]
                     sm = small_multiplier[x]
@@ -395,9 +385,11 @@ def doRealizationSurveyCoveragePickle(
         new_t = t + dt
         if new_t < nextStep:
             t = new_t
-            simData = events.doEvent2(sumRates, cumsumRates, params, simData, new_multiplier)
-            #simData = events.doFreeLive(params, simData, dt)
-            #freeliveTime = nextStep
+            simData = events.doEvent2(
+                sumRates, cumsumRates, params, simData, new_multiplier
+            )
+            # simData = events.doFreeLive(params, simData, dt)
+            # freeliveTime = nextStep
         else:
             simData = events.doFreeLive(params, simData, nextStep - freeliveTime)
             t = nextStep
@@ -405,24 +397,30 @@ def doRealizationSurveyCoveragePickle(
             timeBarrier = nextStep
             # ageing and death
             if timeBarrier >= nextAgeTime:
-
                 simData = events.doDeath(params, simData, t)
 
                 nextAgeTime += ageingInt
             if timeBarrier >= nextOutTime:
-
-
-                simData, _ = events.conductSurvey(simData, params, t, params.N, params.nSamples, surveyType, False)
+                simData, _ = events.conductSurvey(
+                    simData, params, t, params.N, params.nSamples, surveyType, False
+                )
                 SD = copy.deepcopy(simData)
-                wormsTotal = sum(simData.worms.total) 
+                wormsTotal = sum(simData.worms.total)
                 if wormsTotal == 0:
                     trueElim = 1
                 else:
                     trueElim = 0
-                eggCounts = utils.getSetOfEggCounts(SD.worms.total, SD.worms.female, SD.sv, params,  
-                                              params.Unfertilized, params.nSamples, surveyType)
+                eggCounts = utils.getSetOfEggCounts(
+                    SD.worms.total,
+                    SD.worms.female,
+                    SD.sv,
+                    params,
+                    params.Unfertilized,
+                    params.nSamples,
+                    surveyType,
+                )
                 # get approximate prevalence of the population
-                prev = len(np.where(eggCounts > 0)[0])/len(eggCounts)
+                prev = len(np.where(eggCounts > 0)[0]) / len(eggCounts)
                 if len(results) > 0:
                     # get ids of people who had 0 eggs last time step
                     previousZeros = results[-1].id[np.where(results[-1].eggCounts == 0)]
@@ -431,7 +429,9 @@ def doRealizationSurveyCoveragePickle(
                     # get the intersection of these ids, as this is the incidence in this timestep
                     pp = np.intersect1d(nonZeros, previousZeros)
                     # get the ages of these people to add to the results
-                    incidenceAges = t - SD.demography.birthDate[np.where(np.isin(SD.id, pp))]
+                    incidenceAges = (
+                        t - SD.demography.birthDate[np.where(np.isin(SD.id, pp))]
+                    )
                 else:
                     incidenceAges = []
                 results.append(
@@ -446,7 +446,9 @@ def doRealizationSurveyCoveragePickle(
                         compliers=copy.deepcopy(simData.compliers),
                         si=copy.deepcopy(simData.si),
                         sv=copy.deepcopy(simData.sv),
-                        contactAgeGroupIndices=copy.deepcopy(simData.contactAgeGroupIndices),
+                        contactAgeGroupIndices=copy.deepcopy(
+                            simData.contactAgeGroupIndices
+                        ),
                         nVacc=simData.vaccCount - prevNVacc,
                         nChemo1=simData.nChemo1 - prevNChemo1,
                         nChemo2=simData.nChemo2 - prevNChemo2,
@@ -455,14 +457,14 @@ def doRealizationSurveyCoveragePickle(
                         elimination=trueElim,
                         propChemo1=propChemo1,
                         propChemo2=propChemo2,
-                        propVacc = propVacc,
-                        prevalence = prev,
-                        id = simData.id,
-                        eggCounts = eggCounts,
-                        incidenceAges = incidenceAges
+                        propVacc=propVacc,
+                        prevalence=prev,
+                        id=simData.id,
+                        eggCounts=eggCounts,
+                        incidenceAges=incidenceAges,
                     )
                 )
-                prevNChemo1 = simData.nChemo1 
+                prevNChemo1 = simData.nChemo1
                 prevNChemo2 = simData.nChemo2
                 prevNVacc = simData.vaccCount
                 outTimes[nextOutIndex] = maxTime + 10
@@ -470,32 +472,38 @@ def doRealizationSurveyCoveragePickle(
                 nextOutTime = outTimes[nextOutIndex]
             # survey
             if timeBarrier >= tSurvey:
-                #print("Survey, time = ", t)
+                # print("Survey, time = ", t)
                 simData, prevOne = events.conductSurvey(
-                    simData, params, t, params.sampleSizeOne, params.nSamples, surveyType, True
+                    simData,
+                    params,
+                    t,
+                    params.sampleSizeOne,
+                    params.nSamples,
+                    surveyType,
+                    True,
                 )
                 if params.sampleSizeOne > 0:
                     nSurvey += 1
-                
+
                 # if we pass the survey, then don't continue with MDA
                 if prevOne < params.surveyThreshold:
-                    #print("Passed survey, time = ", t)
+                    # print("Passed survey, time = ", t)
                     surveyPass = 1
                     assert params.MDA is not None
                     for mda in params.MDA:
                         k = np.where(mda.Years > t + 1)
                         mda.Coverage[k] = np.array([0])
-                    #assert params.Vacc is not None
-                    #for vacc in params.Vacc:
+                    # assert params.Vacc is not None
+                    # for vacc in params.Vacc:
                     #    vacc.Years = np.array([maxTime + 10])
-                        
-                    #tSurvey = maxTime + 10
+
+                    # tSurvey = maxTime + 10
                     params.sampleSizeOne = 0
-                #else:
+                # else:
                 tSurvey = t + params.timeToNextSurvey
 
                 (
-                    chemoTiming,    
+                    chemoTiming,
                     VaccTiming,
                     nextChemoTime,
                     nextMDAAge,
@@ -506,10 +514,10 @@ def doRealizationSurveyCoveragePickle(
                     nextVecControlTime,
                     nextVecControlIndex,
                 ) = file_parsing.nextMDAVaccInfo(params)
-                
+
             # chemotherapy
             if timeBarrier >= nextChemoTime:
-                #print("MDA, time = ", t)           
+                # print("MDA, time = ", t)
                 simData = events.doDeath(params, simData, t)
                 assert params.MDA is not None
                 for i in range(len(nextMDAAge)):
@@ -519,19 +527,27 @@ def doRealizationSurveyCoveragePickle(
                     minAge = params.MDA[k].Age[0]
                     maxAge = params.MDA[k].Age[1]
                     label = params.MDA[k].Label
-                    simData, propTreated1, propTreated2 = events.doChemoAgeRange(params, simData, t, minAge, maxAge, cov, label)
+                    simData, propTreated1, propTreated2 = events.doChemoAgeRange(
+                        params, simData, t, minAge, maxAge, cov, label
+                    )
                     if propTreated1 > 0:
-                        propChemo1.append([t, minAge, maxAge, "C1", round(propTreated1,4)])
+                        propChemo1.append(
+                            [t, minAge, maxAge, "C1", round(propTreated1, 4)]
+                        )
                     if propTreated2 > 0:
-                        propChemo2.append([t, minAge, maxAge, "C2", round(propTreated2,4)])
-                    
+                        propChemo2.append(
+                            [t, minAge, maxAge, "C2", round(propTreated2, 4)]
+                        )
+
                 if nChemo == 0:
                     tSurvey = t + params.timeToFirstSurvey
                 if surveyType == "None":
                     tSurvey = maxTime + 10
                 nChemo += 1
 
-                params = file_parsing.overWritePostMDA(params, nextMDAAge, nextChemoIndex)
+                params = file_parsing.overWritePostMDA(
+                    params, nextMDAAge, nextChemoIndex
+                )
 
                 (
                     chemoTiming,
@@ -548,7 +564,7 @@ def doRealizationSurveyCoveragePickle(
 
             # vaccination
             if timeBarrier >= nextVaccTime:
-           #     break
+                #     break
                 simData = events.doDeath(params, simData, t)
                 assert params.Vacc is not None
                 for i in range(len(nextVaccAge)):
@@ -558,11 +574,15 @@ def doRealizationSurveyCoveragePickle(
                     minAge = params.Vacc[k].Age[0]
                     maxAge = params.Vacc[k].Age[1]
                     label = params.Vacc[k].Label
-                    simData, pVacc = events.doVaccineAgeRange(params, simData, t, minAge, maxAge, cov, label)
-                    propVacc.append([t, minAge, maxAge, round(pVacc,4)])
-                    
+                    simData, pVacc = events.doVaccineAgeRange(
+                        params, simData, t, minAge, maxAge, cov, label
+                    )
+                    propVacc.append([t, minAge, maxAge, round(pVacc, 4)])
+
                 nVacc += 1
-                params = file_parsing.overWritePostVacc(params, nextVaccAge, nextVaccIndex)
+                params = file_parsing.overWritePostVacc(
+                    params, nextVaccAge, nextVaccIndex
+                )
 
                 (
                     chemoTiming,
@@ -576,13 +596,14 @@ def doRealizationSurveyCoveragePickle(
                     nextVecControlTime,
                     nextVecControlIndex,
                 ) = file_parsing.nextMDAVaccInfo(params)
-            
-            
+
             if timeBarrier >= nextVecControlTime:
                 cov = params.VecControl[0].Coverage[nextVecControlIndex]
                 simData = events.doVectorControl(params, simData, cov)
-                params = file_parsing.overWritePostVecControl(params, nextVecControlIndex)
-                
+                params = file_parsing.overWritePostVecControl(
+                    params, nextVecControlIndex
+                )
+
                 (
                     chemoTiming,
                     VaccTiming,
@@ -595,9 +616,6 @@ def doRealizationSurveyCoveragePickle(
                     nextVecControlTime,
                     nextVecControlIndex,
                 ) = file_parsing.nextMDAVaccInfo(params)
-            
-
-            
 
             nextStep = min(
                 float(nextOutTime),
@@ -607,117 +625,140 @@ def doRealizationSurveyCoveragePickle(
                 float(nextVaccTime),
                 float(nextVecControlTime),
             )
-  
+
     # results.append(dict(  # attendanceRecord=np.array(simData['attendanceRecord']),
     #     # ageAtChemo=np.array(simData['ageAtChemo']),
     #     # adherenceFactorAtChemo=np.array(simData['adherenceFactorAtChemo'])
     # ))
-  
+
     return results, simData
 
 
-
-def getActualCoverages(results: List[List[helsim_structures.Result]], params: helsim_structures.Parameters, allTimes)-> pd.DataFrame:
-    
-    ind = 0
+def getActualCoverages(
+    results: List[List[helsim_structures.Result]],
+    params: helsim_structures.Parameters,
+    allTimes,
+) -> pd.DataFrame:
     p = copy.deepcopy(params.MDA)
     for i in range(len(p)):
         a1 = p[i].Age[0]
         a2 = p[i].Age[1]
         if i == 0:
             newrows = pd.DataFrame(
-                        {
-                            "Time": allTimes,
-                            "age_start": np.repeat(a1, len(allTimes)),
-                            "age_end": np.repeat(a2, len(allTimes)),
-                            "intensity": np.repeat("None", len(allTimes)),
-                            "species": np.repeat(params.species, len(allTimes)),
-                            "measure": np.repeat("Chemo1Cov", len(allTimes)),
-                            "draw_1": np.repeat(0, len(allTimes)),
-                        }
-                    )
+                {
+                    "Time": allTimes,
+                    "age_start": np.repeat(a1, len(allTimes)),
+                    "age_end": np.repeat(a2, len(allTimes)),
+                    "intensity": np.repeat("None", len(allTimes)),
+                    "species": np.repeat(params.species, len(allTimes)),
+                    "measure": np.repeat("Chemo1Cov", len(allTimes)),
+                    "draw_1": np.repeat(0, len(allTimes)),
+                }
+            )
             df1 = newrows
-                                                 
+
         else:
             newrows = pd.DataFrame(
-                        {
-                            "Time": allTimes,
-                            "age_start": np.repeat(a1, len(allTimes)),
-                            "age_end": np.repeat(a2, len(allTimes)),
-                            "intensity": np.repeat("None", len(allTimes)),
-                            "species": np.repeat(params.species, len(allTimes)),
-                            "measure": np.repeat("Chemo1Cov", len(allTimes)),
-                            "draw_1": np.repeat(0, len(allTimes)),
-                        }
-                    )
-            df1 = pd.concat([df1, newrows], ignore_index = True)
-            
+                {
+                    "Time": allTimes,
+                    "age_start": np.repeat(a1, len(allTimes)),
+                    "age_end": np.repeat(a2, len(allTimes)),
+                    "intensity": np.repeat("None", len(allTimes)),
+                    "species": np.repeat(params.species, len(allTimes)),
+                    "measure": np.repeat("Chemo1Cov", len(allTimes)),
+                    "draw_1": np.repeat(0, len(allTimes)),
+                }
+            )
+            df1 = pd.concat([df1, newrows], ignore_index=True)
+
         newrows = pd.DataFrame(
-                        {
-                            "Time": allTimes,
-                            "age_start": np.repeat(a1, len(allTimes)),
-                            "age_end": np.repeat(a2, len(allTimes)),
-                            "intensity": np.repeat("None", len(allTimes)),
-                            "species": np.repeat(params.species, len(allTimes)),
-                            "measure": np.repeat("Chemo2Cov", len(allTimes)),
-                            "draw_1": np.repeat(0, len(allTimes)),
-                        }
-                    )
-        df1 = pd.concat([df1, newrows], ignore_index = True)
+            {
+                "Time": allTimes,
+                "age_start": np.repeat(a1, len(allTimes)),
+                "age_end": np.repeat(a2, len(allTimes)),
+                "intensity": np.repeat("None", len(allTimes)),
+                "species": np.repeat(params.species, len(allTimes)),
+                "measure": np.repeat("Chemo2Cov", len(allTimes)),
+                "draw_1": np.repeat(0, len(allTimes)),
+            }
+        )
+        df1 = pd.concat([df1, newrows], ignore_index=True)
     p = copy.deepcopy(params.Vacc)
     for i in range(len(p)):
         a1 = p[i].Age[0]
         a2 = p[i].Age[1]
-        
-            
-        newrows = pd.DataFrame(
-                        {
-                            "Time": allTimes,
-                            "age_start": np.repeat(a1, len(allTimes)),
-                            "age_end": np.repeat(a2, len(allTimes)),
-                            "intensity": np.repeat("None", len(allTimes)),
-                            "species": np.repeat(params.species, len(allTimes)),
-                            "measure": np.repeat("VaccCov", len(allTimes)),
-                            "draw_1": np.repeat(0, len(allTimes)),
-                        }
-                    )
-        df1 = pd.concat([df1, newrows], ignore_index = True)
 
-        
+        newrows = pd.DataFrame(
+            {
+                "Time": allTimes,
+                "age_start": np.repeat(a1, len(allTimes)),
+                "age_end": np.repeat(a2, len(allTimes)),
+                "intensity": np.repeat("None", len(allTimes)),
+                "species": np.repeat(params.species, len(allTimes)),
+                "measure": np.repeat("VaccCov", len(allTimes)),
+                "draw_1": np.repeat(0, len(allTimes)),
+            }
+        )
+        df1 = pd.concat([df1, newrows], ignore_index=True)
+
     pp = len(results[0])
-    for i in range(len(results[0][pp-1].propChemo1)):
-        df = results[0][pp-1].propChemo1[i]
+    for i in range(len(results[0][pp - 1].propChemo1)):
+        df = results[0][pp - 1].propChemo1[i]
         t = df[0]
         a1 = df[1]
         a2 = df[2]
-        k = np.where(np.logical_and(df1.measure == "Chemo1Cov", np.logical_and(np.logical_and(df1.Time == t, df1.age_start == a1), df1.age_end == a2)))
-        
+        k = np.where(
+            np.logical_and(
+                df1.measure == "Chemo1Cov",
+                np.logical_and(
+                    np.logical_and(df1.Time == t, df1.age_start == a1),
+                    df1.age_end == a2,
+                ),
+            )
+        )
+
         df1.draw_1.iloc[k] = df[4]
-        
-            
-    for i in range(len(results[0][pp-1].propChemo2)):
-        df = results[0][pp-1].propChemo2[i]
+
+    for i in range(len(results[0][pp - 1].propChemo2)):
+        df = results[0][pp - 1].propChemo2[i]
         t = df[0]
         a1 = df[1]
         a2 = df[2]
-        k = np.where(np.logical_and(df1.measure == "Chemo2Cov", np.logical_and(np.logical_and(df1.Time == t, df1.age_start == a1), df1.age_end == a2)))
-        
+        k = np.where(
+            np.logical_and(
+                df1.measure == "Chemo2Cov",
+                np.logical_and(
+                    np.logical_and(df1.Time == t, df1.age_start == a1),
+                    df1.age_end == a2,
+                ),
+            )
+        )
+
         df1.draw_1.iloc[k] = df[4]
-        
-            
-    for i in range(len(results[0][pp-1].propVacc)):
-        df = results[0][pp-1].propVacc[i]
+
+    for i in range(len(results[0][pp - 1].propVacc)):
+        df = results[0][pp - 1].propVacc[i]
         t = df[0]
         a1 = df[1]
         a2 = df[2]
-        k = np.where(np.logical_and(df1.measure == "VaccCov", np.logical_and(np.logical_and(df1.Time == t, df1.age_start == a1), df1.age_end == a2)))
-        
+        k = np.where(
+            np.logical_and(
+                df1.measure == "VaccCov",
+                np.logical_and(
+                    np.logical_and(df1.Time == t, df1.age_start == a1),
+                    df1.age_end == a2,
+                ),
+            )
+        )
+
         df1.draw_1.iloc[k] = df[3]
-        
-            
+
     return df1
-        
-def getCostData(results: List[List[helsim_structures.Result]], params: helsim_structures.Parameters) -> pd.DataFrame:
+
+
+def getCostData(
+    results: List[List[helsim_structures.Result]], params: helsim_structures.Parameters
+) -> pd.DataFrame:
     df1 = None
     for i, list_res in enumerate(results):
         df = pd.DataFrame(list_res)
@@ -733,7 +774,7 @@ def getCostData(results: List[List[helsim_structures.Result]], params: helsim_st
             #         "draw_1": df["nChemo1"],
             #     })
             # df1 = newrows
-            newrows =  pd.DataFrame(
+            newrows = pd.DataFrame(
                 {
                     "Time": df["time"],
                     "age_start": np.repeat("None", df.shape[0]),
@@ -747,89 +788,90 @@ def getCostData(results: List[List[helsim_structures.Result]], params: helsim_st
             df1 = newrows
         else:
             assert df1 is not None
-        #     newrows = pd.DataFrame(
-        #             {
-        #                 "Time": df["time"],
-        #                 "age_start": np.repeat("None", df.shape[0]),
-        #                 "age_end": np.repeat("None", df.shape[0]),
-        #                 "intensity": np.repeat("None", df.shape[0]),
-        #                 "species": np.repeat(params.species, df.shape[0]),
-        #                 "measure": np.repeat("nChemo1", df.shape[0]),
-        #                 "draw_1": df["nChemo1"],
-        #             }
-        #         )
-            
-        #     df1 = pd.concat([df1, newrows], ignore_index = True)
-        # newrows = pd.DataFrame(
-        #         {
-        #             "Time": df["time"],
-        #             "age_start": np.repeat("None", df.shape[0]),
-        #             "age_end": np.repeat("None", df.shape[0]),
-        #             "intensity": np.repeat("None", df.shape[0]),
-        #             "species": np.repeat(params.species, df.shape[0]),
-        #             "measure": np.repeat("nChemo2", df.shape[0]),
-        #             "draw_1": df["nChemo2"],
-        #         }
-        #     )
-        # df1 = pd.concat([df1, newrows], ignore_index = True)
+            #     newrows = pd.DataFrame(
+            #             {
+            #                 "Time": df["time"],
+            #                 "age_start": np.repeat("None", df.shape[0]),
+            #                 "age_end": np.repeat("None", df.shape[0]),
+            #                 "intensity": np.repeat("None", df.shape[0]),
+            #                 "species": np.repeat(params.species, df.shape[0]),
+            #                 "measure": np.repeat("nChemo1", df.shape[0]),
+            #                 "draw_1": df["nChemo1"],
+            #             }
+            #         )
 
-        # newrows = pd.DataFrame(
-        #         {
-        #             "Time": df["time"],
-        #             "age_start": np.repeat("None", df.shape[0]),
-        #             "age_end": np.repeat("None", df.shape[0]),
-        #             "intensity": np.repeat("None", df.shape[0]),
-        #             "species": np.repeat(params.species, df.shape[0]),
-        #             "measure": np.repeat("nVacc", df.shape[0]),
-        #             "draw_1": df["nVacc"],
-        #         }
-        #     )
-        # df1 = pd.concat([df1, newrows], ignore_index = True)
+            #     df1 = pd.concat([df1, newrows], ignore_index = True)
+            # newrows = pd.DataFrame(
+            #         {
+            #             "Time": df["time"],
+            #             "age_start": np.repeat("None", df.shape[0]),
+            #             "age_end": np.repeat("None", df.shape[0]),
+            #             "intensity": np.repeat("None", df.shape[0]),
+            #             "species": np.repeat(params.species, df.shape[0]),
+            #             "measure": np.repeat("nChemo2", df.shape[0]),
+            #             "draw_1": df["nChemo2"],
+            #         }
+            #     )
+            # df1 = pd.concat([df1, newrows], ignore_index = True)
 
-            newrows =  pd.DataFrame(
-                    {
-                        "Time": df["time"],
-                        "age_start": np.repeat("None", df.shape[0]),
-                        "age_end": np.repeat("None", df.shape[0]),
-                        "intensity": np.repeat("None", df.shape[0]),
-                        "species": np.repeat(params.species, df.shape[0]),
-                        "measure": np.repeat("nSurvey", df.shape[0]),
-                        "draw_1": df["nSurvey"],
-                    }
-                )
-            df1 = pd.concat([df1, newrows], ignore_index = True)
+            # newrows = pd.DataFrame(
+            #         {
+            #             "Time": df["time"],
+            #             "age_start": np.repeat("None", df.shape[0]),
+            #             "age_end": np.repeat("None", df.shape[0]),
+            #             "intensity": np.repeat("None", df.shape[0]),
+            #             "species": np.repeat(params.species, df.shape[0]),
+            #             "measure": np.repeat("nVacc", df.shape[0]),
+            #             "draw_1": df["nVacc"],
+            #         }
+            #     )
+            # df1 = pd.concat([df1, newrows], ignore_index = True)
 
-        newrows = pd.DataFrame(
+            newrows = pd.DataFrame(
                 {
                     "Time": df["time"],
                     "age_start": np.repeat("None", df.shape[0]),
                     "age_end": np.repeat("None", df.shape[0]),
                     "intensity": np.repeat("None", df.shape[0]),
                     "species": np.repeat(params.species, df.shape[0]),
-                    "measure": np.repeat("surveyPass", df.shape[0]),
-                    "draw_1": df["surveyPass"],
+                    "measure": np.repeat("nSurvey", df.shape[0]),
+                    "draw_1": df["nSurvey"],
                 }
             )
-        df1 = pd.concat([df1, newrows], ignore_index = True)
+            df1 = pd.concat([df1, newrows], ignore_index=True)
+
         newrows = pd.DataFrame(
-                {
-                    "Time": df["time"],
-                    "age_start": np.repeat("None", df.shape[0]),
-                    "age_end": np.repeat("None", df.shape[0]),
-                    "intensity": np.repeat("None", df.shape[0]),
-                    "species": np.repeat(params.species, df.shape[0]),
-                    "measure": np.repeat("trueElimination", df.shape[0]),
-                    "draw_1": df["elimination"],
-                }
-            )
-        df1 = pd.concat([df1, newrows], ignore_index = True)
+            {
+                "Time": df["time"],
+                "age_start": np.repeat("None", df.shape[0]),
+                "age_end": np.repeat("None", df.shape[0]),
+                "intensity": np.repeat("None", df.shape[0]),
+                "species": np.repeat(params.species, df.shape[0]),
+                "measure": np.repeat("surveyPass", df.shape[0]),
+                "draw_1": df["surveyPass"],
+            }
+        )
+        df1 = pd.concat([df1, newrows], ignore_index=True)
+        newrows = pd.DataFrame(
+            {
+                "Time": df["time"],
+                "age_start": np.repeat("None", df.shape[0]),
+                "age_end": np.repeat("None", df.shape[0]),
+                "intensity": np.repeat("None", df.shape[0]),
+                "species": np.repeat(params.species, df.shape[0]),
+                "measure": np.repeat("trueElimination", df.shape[0]),
+                "draw_1": df["elimination"],
+            }
+        )
+        df1 = pd.concat([df1, newrows], ignore_index=True)
     return df1
 
 
-
-
 def singleSimulationDALYCoverage(
-    params: helsim_structures.Parameters, simData: helsim_structures.SDEquilibrium, surveyType: str, numReps: Optional[int] = None
+    params: helsim_structures.Parameters,
+    simData: helsim_structures.SDEquilibrium,
+    surveyType: str,
+    numReps: Optional[int] = None,
 ) -> pd.DataFrame:
     """
     This function generates multiple simulation paths.
@@ -849,17 +891,16 @@ def singleSimulationDALYCoverage(
 
     # run the simulations
     results, SD = doRealizationSurveyCoveragePickle(params, surveyType, simData)
-    
- 
+
     results = [results]
     # process the output
     output = results_processing.extractHostData(results)
 
     # transform the output to data frame
     df = results_processing.getPrevalenceDALYsAll(
-        output, params, numReps, params.Unfertilized,  'KK1', 1
+        output, params, numReps, params.Unfertilized, "KK1", 1
     )
-         
+
     # wholePopPrev = results_processing.getPrevalenceWholePop(output, params, numReps, params.Unfertilized,  'KK1', 1)
     numAgeGroup = results_processing.outputNumberInAgeGroup(results, params)
     incidence = results_processing.getIncidence(results, params)
@@ -877,10 +918,11 @@ def singleSimulationDALYCoverage(
     df1 = pd.concat([df1, surveyData], ignore_index=True)
     df1 = pd.concat([df1, treatmentData], ignore_index=True)
     df1 = df1.reset_index()
-    df1['draw_1'][np.where(pd.isna(df1['draw_1']))[0]] = -1
-    df1 = df1[['Time','age_start','age_end', 'intensity', 'species', 'measure', 'draw_1']]
+    df1["draw_1"][np.where(pd.isna(df1["draw_1"]))[0]] = -1
+    df1 = df1[
+        ["Time", "age_start", "age_end", "intensity", "species", "measure", "draw_1"]
+    ]
     return df1, SD
-
 
 
 def getDesiredAgeDistribution(params, timeLimit):
@@ -888,24 +930,25 @@ def getDesiredAgeDistribution(params, timeLimit):
     # initialize birth and death ages from population
     deathAges = getLifeSpans(params.N, params)
     birthAges = np.zeros(params.N)
-    # age population for a chosen number of years in order to generate 
+    # age population for a chosen number of years in order to generate
     # wanted age distribution
     while t < timeLimit:
         t = min(deathAges)
         theDead = np.where(deathAges == t)[0]
         newDeathAges = getLifeSpans(len(theDead), params)
         deathAges[theDead] = newDeathAges + t
-        birthAges[theDead] =  t
+        birthAges[theDead] = t
     ages = t - birthAges
     deathAges = deathAges - t
-    aa = np.zeros([len(ages),2])
-    aa[:,0] = ages
-    aa[:,1] = deathAges
+    aa = np.zeros([len(ages), 2])
+    aa[:, 0] = ages
+    aa[:, 1] = deathAges
     b = aa
     ord1 = aa[:, 0].argsort()
-    b[:,0] = aa[ord1,0]
-    b[:,1] = deathAges[ord1]
+    b[:, 0] = aa[ord1, 0]
+    b[:, 1] = deathAges[ord1]
     return b
+
 
 def splitSimDataIntoAges(ages, ageGroups):
     # this function should return an array which contains the location of individuals in the pickle
@@ -914,14 +957,14 @@ def splitSimDataIntoAges(ages, ageGroups):
     # ageGroups is different splits in the ages to choose individuals from
     groupAges = []
     for i in range(1, len(ageGroups)):
-        k1 = ages >= ageGroups[i-1]
+        k1 = ages >= ageGroups[i - 1]
         k2 = ages < ageGroups[i]
         k = np.where(np.logical_and(k1, k2))
-        
-        groupAges.append(dict(
-                              minAge = ageGroups[i-1],maxAge= ageGroups[i],
-                         indices = k[0]))
-    
+
+        groupAges.append(
+            dict(minAge=ageGroups[i - 1], maxAge=ageGroups[i], indices=k[0])
+        )
+
     return groupAges
 
 
@@ -930,30 +973,36 @@ def findNumberOfPeopleEachAgeGroup(chosenAges, groupAges):
     # chosenAges is the age of people in the wanted distribution
     numIndivsToChoose = []
     for i in range(len(groupAges)):
-        minAge = groupAges[i]['minAge']
-        maxAge = groupAges[i]['maxAge']
+        minAge = groupAges[i]["minAge"]
+        maxAge = groupAges[i]["maxAge"]
         k1 = chosenAges >= minAge
         k2 = chosenAges < maxAge
-        numIndivsToChoose.append(len(np.where(np.logical_and(k1,k2))[0]))
+        numIndivsToChoose.append(len(np.where(np.logical_and(k1, k2))[0]))
     return numIndivsToChoose
 
 
-def selectIndividuals(chosenAges,  groupAges, numIndivsToChoose):
-    chosenIndivs = np.zeros(sum(numIndivsToChoose) ,dtype = int)
+def selectIndividuals(chosenAges, groupAges, numIndivsToChoose):
+    chosenIndivs = np.zeros(sum(numIndivsToChoose), dtype=int)
     startPoint = 0
-    totalPeople = 0
     for i in range(len(numIndivsToChoose)):
         n1 = numIndivsToChoose[i]
-        indivs = np.array(groupAges[i]['indices'])
-        chosenIndivs[range(startPoint,startPoint+n1)] =  np.random.choice(a=indivs, size=n1, replace=True)
+        indivs = np.array(groupAges[i]["indices"])
+        chosenIndivs[range(startPoint, startPoint + n1)] = np.random.choice(
+            a=indivs, size=n1, replace=True
+        )
         startPoint += n1
     return chosenIndivs
 
 
-
 def multiple_simulations(
-    params: helsim_structures.Parameters, pickleData, simparams, indices, i, surveyType, wantedPopSize = 3000,
-    ageGroups = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 100]
+    params: helsim_structures.Parameters,
+    pickleData,
+    simparams,
+    indices,
+    i,
+    surveyType,
+    wantedPopSize=3000,
+    ageGroups=[0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 100],
 ) -> pd.DataFrame:
     print(f"==> multiple_simulations starting sim {i}")
     start_time = time.time()
@@ -976,9 +1025,15 @@ def multiple_simulations(
 
     raw_data = dict((key, copy.deepcopy(data[key])) for key in keys)
     times = data["times"]
-    raw_data["demography"]["birthDate"] = raw_data["demography"]["birthDate"] - times["maxTime"]
-    raw_data["demography"]["deathDate"] = raw_data["demography"]["deathDate"]- times["maxTime"]
-    worms = helsim_structures.Worms(total=raw_data["worms"]["total"], female=raw_data["worms"]["female"])
+    raw_data["demography"]["birthDate"] = (
+        raw_data["demography"]["birthDate"] - times["maxTime"]
+    )
+    raw_data["demography"]["deathDate"] = (
+        raw_data["demography"]["deathDate"] - times["maxTime"]
+    )
+    worms = helsim_structures.Worms(
+        total=raw_data["worms"]["total"], female=raw_data["worms"]["female"]
+    )
     demography = helsim_structures.Demography(
         birthDate=raw_data["demography"]["birthDate"],
         deathDate=raw_data["demography"]["deathDate"],
@@ -995,10 +1050,10 @@ def multiple_simulations(
         attendanceRecord=[],
         ageAtChemo=[],
         adherenceFactorAtChemo=[],
-        n_treatments = {},
-        n_treatments_population = {},
-        n_surveys = {},
-        n_surveys_population = {},
+        n_treatments={},
+        n_treatments_population={},
+        n_surveys={},
+        n_surveys_population={},
         vaccCount=0,
         nChemo1=0,
         nChemo2=0,
@@ -1006,15 +1061,15 @@ def multiple_simulations(
         compliers=np.random.uniform(low=0, high=1, size=len(raw_data["si"]))
         > params.propNeverCompliers,
         adherenceFactors=np.random.uniform(low=0, high=1, size=len(raw_data["si"])),
-        id = ids
+        id=ids,
     )
     pickleNumIndivs = len(simData.si)
-    #print("starting  j =",j)
+    # print("starting  j =",j)
     if pickleNumIndivs < wantedPopSize:
         # set population size to wanted population size
         params.N = wantedPopSize
         # get the birth and death ages of representative population
-        b = getDesiredAgeDistribution(params, timeLimit = 200)
+        b = getDesiredAgeDistribution(params, timeLimit=200)
         chosenAges = b[:, 0]
         deathDate = b[:, 1]
         # ages of pickle file data
@@ -1022,11 +1077,11 @@ def multiple_simulations(
         # group these ages into age groups
         groupAges = splitSimDataIntoAges(ages, ageGroups)
         # how many people in each age group do we need to pick to match representative population
-        numIndivsToChoose = findNumberOfPeopleEachAgeGroup(chosenAges,  groupAges)
+        numIndivsToChoose = findNumberOfPeopleEachAgeGroup(chosenAges, groupAges)
         # choose these people from the pickle data
         chosenIndivs = selectIndividuals(chosenAges, groupAges, numIndivsToChoose)
         birthDate = -chosenAges - 0.000001
-        deathDate = deathDate 
+        deathDate = deathDate
         wormsT = []
         wormsF = []
         si = []
@@ -1036,40 +1091,44 @@ def multiple_simulations(
             si.append(simData.si[chosenIndivs[k]])
             wormsT.append(simData.worms.total[chosenIndivs[k]])
             wormsF.append(simData.worms.female[chosenIndivs[k]])
-            contactAgeGroupIndices.append(simData.contactAgeGroupIndices[chosenIndivs[k]])
-            treatmentAgeGroupIndices.append(simData.treatmentAgeGroupIndices[chosenIndivs[k]])
+            contactAgeGroupIndices.append(
+                simData.contactAgeGroupIndices[chosenIndivs[k]]
+            )
+            treatmentAgeGroupIndices.append(
+                simData.treatmentAgeGroupIndices[chosenIndivs[k]]
+            )
         demography = helsim_structures.Demography(
-        birthDate=np.array(birthDate),
-        deathDate=np.array(deathDate),
+            birthDate=np.array(birthDate),
+            deathDate=np.array(deathDate),
         )
         worms = helsim_structures.Worms(total=np.array(wormsT), female=np.array(wormsF))
         ids = np.arange(wantedPopSize)
         SD = helsim_structures.SDEquilibrium(
-        si=np.array(si),
-        worms=worms,
-        freeLiving=raw_data["freeLiving"],
-        demography=demography,
-        contactAgeGroupIndices=np.array(contactAgeGroupIndices),
-        treatmentAgeGroupIndices=np.array(treatmentAgeGroupIndices),
-        sv=np.zeros(wantedPopSize, dtype=int),
-        attendanceRecord=[],
-        ageAtChemo=[],
-        adherenceFactorAtChemo=[],
-        n_treatments = {},
-        n_treatments_population = {},
-        n_surveys = {},
-        n_surveys_population = {},
-        vaccCount=0,
-        nChemo1=0,
-        nChemo2=0,
-        numSurvey=0,
-        compliers=np.random.uniform(low=0, high=1, size=wantedPopSize)
-        > params.propNeverCompliers,
-        adherenceFactors=np.random.uniform(low=0, high=1, size=wantedPopSize),
-        id = ids
+            si=np.array(si),
+            worms=worms,
+            freeLiving=raw_data["freeLiving"],
+            demography=demography,
+            contactAgeGroupIndices=np.array(contactAgeGroupIndices),
+            treatmentAgeGroupIndices=np.array(treatmentAgeGroupIndices),
+            sv=np.zeros(wantedPopSize, dtype=int),
+            attendanceRecord=[],
+            ageAtChemo=[],
+            adherenceFactorAtChemo=[],
+            n_treatments={},
+            n_treatments_population={},
+            n_surveys={},
+            n_surveys_population={},
+            vaccCount=0,
+            nChemo1=0,
+            nChemo2=0,
+            numSurvey=0,
+            compliers=np.random.uniform(low=0, high=1, size=wantedPopSize)
+            > params.propNeverCompliers,
+            adherenceFactors=np.random.uniform(low=0, high=1, size=wantedPopSize),
+            id=ids,
         )
         simData = copy.deepcopy(SD)
-        
+
     # Convert all layers to correct data format
 
     # extract the previous random state
@@ -1109,9 +1168,14 @@ def multiple_simulations(
     return df, simData
 
 
-
 def multiple_simulations_after_burnin(
-    params: helsim_structures.Parameters, pickleData, simparams, indices, i, burnInTime, surveyType
+    params: helsim_structures.Parameters,
+    pickleData,
+    simparams,
+    indices,
+    i,
+    burnInTime,
+    surveyType,
 ) -> pd.DataFrame:
     print(f"==> after burn in starting sim {i}")
     start_time = time.time()
@@ -1121,14 +1185,14 @@ def multiple_simulations_after_burnin(
     # load the previous simulation results
     raw_data = pickleData[j]
 
-    
     t = 0
 
     raw_data.demography.birthDate = raw_data.demography.birthDate - burnInTime
-    raw_data.demography.deathDate = raw_data.demography.deathDate - burnInTime 
+    raw_data.demography.deathDate = raw_data.demography.deathDate - burnInTime
 
-    
-    worms = helsim_structures.Worms(total=raw_data.worms.total, female=raw_data.worms.female)
+    worms = helsim_structures.Worms(
+        total=raw_data.worms.total, female=raw_data.worms.female
+    )
     demography = helsim_structures.Demography(
         birthDate=raw_data.demography.birthDate,
         deathDate=raw_data.demography.deathDate,
@@ -1144,10 +1208,10 @@ def multiple_simulations_after_burnin(
         attendanceRecord=[],
         ageAtChemo=[],
         adherenceFactorAtChemo=[],
-        n_treatments = {},
-        n_treatments_population = {},
-        n_surveys = {},
-        n_surveys_population = {},
+        n_treatments={},
+        n_treatments_population={},
+        n_surveys={},
+        n_surveys_population={},
         vaccCount=0,
         nChemo1=0,
         nChemo2=0,
@@ -1155,9 +1219,9 @@ def multiple_simulations_after_burnin(
         compliers=np.random.uniform(low=0, high=1, size=len(raw_data.si))
         > params.propNeverCompliers,
         adherenceFactors=np.random.uniform(low=0, high=1, size=len(raw_data.si)),
-        id = np.arange(len(raw_data.si))
+        id=np.arange(len(raw_data.si)),
     )
-    
+
     # Convert all layers to correct data format
 
     # extract the previous random state
@@ -1197,36 +1261,33 @@ def multiple_simulations_after_burnin(
     return df, simData
 
 
-
-
 def BurnInSimulations(
     params: helsim_structures.Parameters, simparams, i, surveyType
 ) -> pd.DataFrame:
     print(f"==> burn in starting sim {i}")
     start_time = time.time()
-    #copy parameters
+    # copy parameters
     parameters = copy.deepcopy(params)
 
     # update the parameters
     R0 = simparams.iloc[i, 1].tolist()
     k = simparams.iloc[i, 2].tolist()
-    
+
     parameters.R0 = R0
     parameters.k = k
     # configuration.configure the parameters
     parameters = configuration.configure(parameters)
     parameters.psi = utils.getPsi(parameters)
     parameters.equiData = configuration.getEquilibrium(parameters)
-    
+
     # setup starting point form simulation
     simData = configuration.setupSD(parameters)
-    simData.vaccCount=0
-    simData.nChemo1=0
-    simData.nChemo2=0
-    simData.numSurvey=0
+    simData.vaccCount = 0
+    simData.nChemo1 = 0
+    simData.nChemo2 = 0
+    simData.numSurvey = 0
 
-
-    df, simData = singleSimulationDALYCoverage(parameters, simData, surveyType,  1)
+    df, simData = singleSimulationDALYCoverage(parameters, simData, surveyType, 1)
     end_time = time.time()
     total_time = end_time - start_time
     print(f"==> burn in finishing sim {i}: {total_time:.3f}s")
@@ -1234,7 +1295,6 @@ def BurnInSimulations(
 
 
 def getLifeSpans(nSpans: int, params: helsim_structures.Parameters) -> float:
-
     """
     This function draws the lifespans from the population survival curve.
     helsim_structures.Parameters


### PR DESCRIPTION
Fix linter errors raised by `ruff check` (ruff 0.4.9, default settings), see #50 

- Don't use comparison based on call to `type()`
- Avoid single letter variable names
- Comparison to `True`