### PR TITLE
Exclude running numpy2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setuptools.setup(
     long_description='Individual-based model in Medley 1989 thesis and Anderson&Medley 1985.',
     packages=setuptools.find_packages(),
     python_requires='>=3.9,<3.11',
-    install_requires=['numpy', 'scipy', 'pandas', 'joblib', 'matplotlib', 'openpyxl', 'pytest'],
+    install_requires=['numpy<2.0', 'scipy', 'pandas', 'joblib', 'matplotlib', 'openpyxl', 'pytest'],
     include_package_data=True
 )


### PR DESCRIPTION
This introduces API changes and is not compataible with the current version of this repo.