### PR TITLE
Seed used for amis integration

### DIFF
--- a/sch_simulation/amis_integration/amis_integration.py
+++ b/sch_simulation/amis_integration/amis_integration.py
@@ -49,6 +49,9 @@ def returnYearlyPrevalenceEstimate(R0, k, seed, fixed_parameters: FixedParameter
         fixed_parameters.coverage_file_name,
         fixed_parameters.coverage_text_file_storage_name,
     )
+
+    random.seed(seed)
+    np.random.seed(seed)
     # initialize the parameters
     params = sch_simulation.helsim_RUN_KK.loadParameters(
         fixed_parameters.parameter_file_name, fixed_parameters.demography_name
@@ -120,7 +123,7 @@ def run_model_with_parameters(
         R0 = parameter_set[0]
         k = parameter_set[1]
 
-        results = returnYearlyPrevalenceEstimate(R0, k, fixed_parameters)
+        results = returnYearlyPrevalenceEstimate(R0, k, seed, fixed_parameters)
 
         prevalence = extract_relevant_results(
             results, year_indices

--- a/sch_simulation/amis_integration/amis_integration.py
+++ b/sch_simulation/amis_integration/amis_integration.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from functools import cache
+import random
 from typing import Literal
 import pandas as pd
 import sch_simulation
@@ -44,8 +44,7 @@ class FixedParameters:
     A higher number will result in faster but less accurate simulation."""
 
 
-@cache
-def returnYearlyPrevalenceEstimate(R0, k, fixed_parameters: FixedParameters):
+def returnYearlyPrevalenceEstimate(R0, k, seed, fixed_parameters: FixedParameters):
     cov = parse_coverage_input(
         fixed_parameters.coverage_file_name,
         fixed_parameters.coverage_text_file_storage_name,

--- a/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
+++ b/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
@@ -30,7 +30,7 @@ test_that("Running the model should give us some results", {
     prevalence_map <- matrix(c(0.5, 0.5), ncol = 1)
 
     tranmission_model <- build_transmission_model(prevalence_map, example_parameters, year_indices = c(23))
-    result <- tranmission_model(c(1, 2), matrix(c(3, 3, 0.04, 0.04), ncol = 2), 1)
+    result <- tranmission_model(c(1L, 2L), matrix(c(3, 3, 0.04, 0.04), ncol = 2), 1)
     expect_equal(result, matrix(c(0.1, 0.1), ncol = 1), tolerance = 0.5)
 })
 
@@ -44,7 +44,7 @@ test_that("Running the simulation on multiple time points gives multiple points 
     year_indices <- c(0L, 23L)
 
     tranmission_model <- build_transmission_model(prevalence_map, example_parameters, year_indices)
-    result <- tranmission_model(c(1, 2), matrix(c(3, 3, 0.04, 0.04), ncol = 2), 1)
+    result <- tranmission_model(c(1L, 2L), matrix(c(3, 3, 0.04, 0.04), ncol = 2), 1)
     expect_equal(result, matrix(c(0.1, 0.1, 0.1, 0.1), ncol = 2), tolerance = 0.5)
 })
 

--- a/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
+++ b/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
@@ -25,13 +25,13 @@ example_parameters <- sch_simulation$FixedParameters(
         min_multiplier = 5L
     )
 
-test_that("Running the model should give us some results", {
+test_that("Running the model should give us consistent results", {
     # Example prevalence map, with two locations, both with prevalence of 0.5
     prevalence_map <- matrix(c(0.5, 0.5), ncol = 1)
 
     tranmission_model <- build_transmission_model(prevalence_map, example_parameters, year_indices = c(23))
-    result <- tranmission_model(c(1L, 2L), matrix(c(3, 3, 0.04, 0.04), ncol = 2), 1)
-    expect_equal(result, matrix(c(0.1, 0.1), ncol = 1), tolerance = 0.5)
+    result <- tranmission_model(c(1L, 2L), matrix(c(3, 3, 0.3, 0.3), ncol = 2), 1)
+    expect_equal(result, matrix(c(0.0, 0.8), ncol = 1), tolerance = 0.0)
 })
 
 test_that("Running the simulation on multiple time points gives multiple points back", {

--- a/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
+++ b/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
@@ -93,11 +93,14 @@ test_that("Running the AMIS integration on multiple time points should complete 
 
     prior <- list("dprior" = density_function, "rprior" = rnd_function)
 
+    amis_params <- AMISforInfectiousDiseases::default_amis_params()
+    amis_params$n_samples <- 2
 
     expect_error(AMISforInfectiousDiseases::amis(
         prevalence_map,
         build_transmission_model(prevalence_map, example_parameters, year_indices),
-        prior
+        prior,
+        amis_params
     ), "(No weight on any particles for locations in the active set.)|(the leading minor of order 2 is not positive definite)")
 })
 
@@ -120,10 +123,13 @@ test_that("Running the AMIS integration should complete with the error about wei
 
     prior <- list("dprior" = density_function, "rprior" = rnd_function)
 
+    amis_params <- AMISforInfectiousDiseases::default_amis_params()
+    amis_params$n_samples <- 2
 
     expect_error(AMISforInfectiousDiseases::amis(
         prevalence_map,
         build_transmission_model(prevalence_map, example_parameters, year_indices = c(23)),
-        prior
+        prior,
+        amis_params
     ), "(No weight on any particles for locations in the active set.)|(the leading minor of order 2 is not positive definite)")
 })

--- a/tests/amis_integration/test_amis_integration.py
+++ b/tests/amis_integration/test_amis_integration.py
@@ -1,8 +1,41 @@
 import pytest
-from sch_simulation.amis_integration.amis_integration import extract_relevant_results
+from sch_simulation.amis_integration.amis_integration import extract_relevant_results, returnYearlyPrevalenceEstimate, FixedParameters
 import pandas as pd
 from pandas import testing as pdt
 
+example_parameters = FixedParameters(
+        # the higher the value of N, the more consistent the results will be
+        # though the longer the simulation will take
+        number_hosts = 10,
+        # no intervention
+        coverage_file_name = "mansoni_coverage_scenario_0.xlsx",
+        demography_name = "UgandaRural",
+        # cset the survey type to Kato Katz with duplicate slide
+        survey_type = "KK2",
+        parameter_file_name = "mansoni_params.txt",
+        coverage_text_file_storage_name = "Man_MDA_vacc.txt",
+        # the following number dictates the number of events (e.g. worm deaths)
+        # we allow to happen before updating other parts of the model
+        # the higher this number the faster the simulation
+        # (though there is a check so that there can't be too many events at once)
+        # the higher the number the greater the potential for
+        # errors in the model accruing.
+        # 5 is a reasonable level of compromise for speed and errors, but using
+        # a lower value such as 3 is also quite good
+        min_multiplier = 5
+    )
+
+def test_running_model_produces_consistent_result():
+    results_with_seed1 = returnYearlyPrevalenceEstimate(3.0, 0.3, seed=1, fixed_parameters=example_parameters)
+    print(results_with_seed1['draw_1'])
+    expected_prevalance = [0.5, 0.2, 0.3, 0.2, 0.2, 0.2, 0.1, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    pdt.assert_series_equal(results_with_seed1['draw_1'], pd.Series(expected_prevalance, name="draw_1"))
+
+def test_running_model_with_different_seed_gives_different_result():
+    results_with_seed1 = returnYearlyPrevalenceEstimate(3.0, 0.3, seed=1, fixed_parameters=example_parameters)
+    results_with_seed2 = returnYearlyPrevalenceEstimate(3.0, 0.3, seed=2, fixed_parameters=example_parameters)
+    with pytest.raises(AssertionError):
+        pdt.assert_frame_equal(results_with_seed1, results_with_seed2)
 
 def test_extract_data():
     example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], "draw_1": [0.1, 0.2, 0.3]})


### PR DESCRIPTION
Fixes NTD-Modelling-Consortium/endgame-project#18

This sets a seed provided by the AMIS algorithm before doing any stochastic parts of the simulation. This ensures the model will give consistent outputs given consistent inputs. 

Both numpy.random and the python standard library random are used, therefore both seeds are required. 

Currently there is no consistent entry point for the model, so the seed setting ends up going in the amis integration. Raised NTD-Modelling-Consortium/endgame-project#57 for fixing this. 

Also using a legacy way of generating random numbers in numpy, raised NTD-Modelling-Consortium/endgame-project#56 to fix that in the future. 