### PR TITLE
Fix type errors

### DIFF
--- a/sch_simulation/helsim_FUNC_KK/helsim_structures.py
+++ b/sch_simulation/helsim_FUNC_KK/helsim_structures.py
@@ -166,10 +166,10 @@ class SDEquilibrium:
     numSurvey: int
     id: ndarray
     treatProbability: ndarray
-    n_treatments: Optional[dict[str, np.ndarray[np.float_]]]
-    n_treatments_population: Optional[dict[str, np.ndarray[np.float_]]] 
-    n_surveys: Optional[dict[str, np.ndarray[np.float_]]] 
-    n_surveys_population: Optional[dict[str, np.ndarray[np.float_]]] 
+    n_treatments: Optional[dict[str, NDArray[np.float_]]]
+    n_treatments_population: Optional[dict[str, NDArray[np.float_]]] 
+    n_surveys: Optional[dict[str, NDArray[np.float_]]] 
+    n_surveys_population: Optional[dict[str, NDArray[np.float_]]] 
     numSurveyTwo: Optional[int] = None
     vaccinatedFactors: Optional[ndarray] = None
     VaccTreatmentAgeGroupIndices: Optional[ndarray] = None

--- a/sch_simulation/helsim_FUNC_KK/utils.py
+++ b/sch_simulation/helsim_FUNC_KK/utils.py
@@ -153,6 +153,7 @@ def getSetOfEggCountsv2(
             
         
         return count_ids / params.weight_sample
+    raise ValueError(f"Unsupported surveyType: {surveyType}")
         # eggs = np.random.negative_binomial(size=len(meanCount), p=params.k_epg / (meanCount + params.k_epg), n=params.k_epg)
         # for i in range(nSamples):
         #     eggs +=  np.random.negative_binomial(

--- a/sch_simulation/helsim_FUNC_KK/utils.py
+++ b/sch_simulation/helsim_FUNC_KK/utils.py
@@ -80,7 +80,7 @@ def getSetOfEggCountsv2(
     Unfertilized: bool,
     nSamples: int = 2,
     surveyType: str = 'KK2'
-) -> NDArray[np.int_]:
+) -> NDArray[np.float_]:
 
     """
     This function returns a set of readings of egg counts from a vector of individuals,


### PR DESCRIPTION
When running in the cluster, these type errors were preventing reticulate from loading the module. I don't really understand why, but there is no harm in fixing these issues. 

This is not all of the type errors in the code (there are over 200) but it is enough for the module to load. The others seemed potentially more difficult to fix, but we should still do that and then turn on a static type checker in CI. 

Fixes NTD-Modelling-Consortium/EndGame-Project#89