### PR TITLE
RScript accepting number of cores to use

### DIFF
--- a/sch_simulation/amis_integration/amis_integration.R
+++ b/sch_simulation/amis_integration/amis_integration.R
@@ -5,7 +5,7 @@ get_amis_integration_package <- function() {
   return(sch_simulation)
 }
 
-build_transmission_model <- function(prevalence_map, fixed_parameters, year_indices) {
+build_transmission_model <- function(prevalence_map, fixed_parameters, year_indices, num_cores) {
   if(is.list(prevalence_map)) {
     if(length(prevalence_map) != length(year_indices)) {
       error_string <- sprintf("Length of prevalance map (%i) must match the number of years provided in year_indices (%i)", length(prevalence_map), length(year_indices))
@@ -24,7 +24,7 @@ build_transmission_model <- function(prevalence_map, fixed_parameters, year_indi
     output <- sch_simulation$run_model_with_parameters(
       # If year indices in just a single element, without as.array it will
       # automatically be converted into a scalar
-      seeds, params, fixed_parameters, as.array(year_indices)
+      seeds, params, fixed_parameters, as.array(year_indices), as.integer(num_cores)
     )
     return(output)
   }

--- a/sch_simulation/amis_integration/amis_integration.py
+++ b/sch_simulation/amis_integration/amis_integration.py
@@ -130,6 +130,8 @@ def run_model_with_parameters(
         raise ValueError(
             f"Must have same number of seeds as parameters {len(seeds)} != {len(parameters)}"
         )
+    
+    print(f'Running {len(seeds)} simulations across {num_parallel_jobs} cores')
 
     num_runs = len(seeds)
 

--- a/sch_simulation/amis_integration/amis_integration.py
+++ b/sch_simulation/amis_integration/amis_integration.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import random
+import time
 from typing import Literal
 import pandas as pd
 import sch_simulation
@@ -107,11 +108,17 @@ def extract_relevant_results(
 
     return prevalence_for_relevant_years
 
-def run_and_extract_results(parameter_set, seed, fixed_parameters, year_indices):
+def run_and_extract_results(parameter_set, seed, fixed_parameters, year_indices, include_output=False):
     R0 = parameter_set[0]
     k = parameter_set[1]
 
+    start_time = time.time()
+
     results = returnYearlyPrevalenceEstimate(R0, k, seed, fixed_parameters)
+
+    end_time = time.time()
+    if include_output:
+        print(f'Run R0: {R0}, k: {k} took {end_time-start_time:10.2f} seconds')
 
     return extract_relevant_results(results, year_indices)
 
@@ -126,9 +133,11 @@ def run_model_with_parameters(
 
     num_runs = len(seeds)
 
+    print_timing_info_every_n_times = 10
+
     final_prevalence_for_each_run = Parallel(n_jobs=num_parallel_jobs)(delayed(run_and_extract_results)
-        (parameter_set, seed, fixed_parameters, year_indices) 
-        for seed, parameter_set in zip(seeds, parameters))
+        (parameter_set, seed, fixed_parameters, year_indices, include_output=index % print_timing_info_every_n_times == 0) 
+        for index, (seed, parameter_set) in enumerate(zip(seeds, parameters)))
 
     results_np_array = np.array(final_prevalence_for_each_run).reshape(
         num_runs, len(year_indices)

--- a/sch_simulation/amis_integration/sth_fitting.R
+++ b/sch_simulation/amis_integration/sth_fitting.R
@@ -1,5 +1,13 @@
 source("amis_integration.R")
 
+args <- commandArgs(trailingOnly=TRUE)
+num_cores_to_use <- parallel::detectCores()
+if(length(args) == 1) {
+    num_cores_to_use <- as.integer(args)
+}
+
+print(paste0('Using ', num_cores_to_use, ' cores'))
+
 sch_simulation <- get_amis_integration_package()
 
 fixed_parameters <- sch_simulation$FixedParameters(
@@ -46,8 +54,7 @@ rnd_function <- function(num_samples) {
 prior <- list("dprior" = density_function, "rprior" = rnd_function)
 
 year_indices <- c(0L, 23L)
-# This doesn't work correctly on the cluster - need to accept as argument
-num_cores_to_use <- parallel::detectCores()
+
 
 amis_output <- AMISforInfectiousDiseases::amis(
     prevalence_map,

--- a/sch_simulation/amis_integration/sth_fitting.R
+++ b/sch_simulation/amis_integration/sth_fitting.R
@@ -46,10 +46,12 @@ rnd_function <- function(num_samples) {
 prior <- list("dprior" = density_function, "rprior" = rnd_function)
 
 year_indices <- c(0L, 23L)
+# This doesn't work correctly on the cluster - need to accept as argument
+num_cores_to_use <- parallel::detectCores()
 
 amis_output <- AMISforInfectiousDiseases::amis(
     prevalence_map,
-    build_transmission_model(prevalence_map, fixed_parameters, year_indices),
+    build_transmission_model(prevalence_map, fixed_parameters, year_indices, num_cores_to_use),
     prior
 )
 

--- a/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
+++ b/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
@@ -29,7 +29,7 @@ test_that("Running the model should give us consistent results", {
     # Example prevalence map, with two locations, both with prevalence of 0.5
     prevalence_map <- matrix(c(0.5, 0.5), ncol = 1)
 
-    tranmission_model <- build_transmission_model(prevalence_map, example_parameters, year_indices = c(23))
+    tranmission_model <- build_transmission_model(prevalence_map, example_parameters, year_indices = c(23), 2)
     result <- tranmission_model(c(1L, 2L), matrix(c(3, 3, 0.3, 0.3), ncol = 2), 1)
     expect_equal(result, matrix(c(0.0, 0.5), ncol = 1), tolerance = 0.0)
 })
@@ -43,7 +43,7 @@ test_that("Running the simulation on multiple time points gives multiple points 
 
     year_indices <- c(0L, 23L)
 
-    tranmission_model <- build_transmission_model(prevalence_map, example_parameters, year_indices)
+    tranmission_model <- build_transmission_model(prevalence_map, example_parameters, year_indices, 2)
     result <- tranmission_model(c(1L, 2L), matrix(c(3, 3, 0.04, 0.04), ncol = 2), 1)
     expect_equal(result, matrix(c(0.1, 0.1, 0.1, 0.1), ncol = 2), tolerance = 0.5)
 })
@@ -54,7 +54,7 @@ test_that("Running the simulation with different number of years specified compa
 
     year_indices <- c(0L, 23L)
 
-    expect_error(build_transmission_model(prevalence_map, example_parameters, year_indices), "Single time point prevalance map provided so should only request one year but 2 provided")
+    expect_error(build_transmission_model(prevalence_map, example_parameters, year_indices, 2), "Single time point prevalance map provided so should only request one year but 2 provided")
 })
 
 test_that("Running the simulation with different number of years specified compared to the prevalance map raises an error", {
@@ -66,7 +66,7 @@ test_that("Running the simulation with different number of years specified compa
 
     year_indices <- c(23L)
 
-    expect_error(build_transmission_model(prevalence_map, example_parameters, year_indices), "Length of prevalance map \\(2\\) must match the number of years provided in year_indices \\(1\\)")
+    expect_error(build_transmission_model(prevalence_map, example_parameters, year_indices, 2), "Length of prevalance map \\(2\\) must match the number of years provided in year_indices \\(1\\)")
 })
 
 test_that("Running the AMIS integration on multiple time points should complete with the error about weight on particles", {
@@ -98,7 +98,7 @@ test_that("Running the AMIS integration on multiple time points should complete 
 
     expect_error(AMISforInfectiousDiseases::amis(
         prevalence_map,
-        build_transmission_model(prevalence_map, example_parameters, year_indices),
+        build_transmission_model(prevalence_map, example_parameters, year_indices, 2),
         prior,
         amis_params
     ), "(No weight on any particles for locations in the active set.)|(the leading minor of order 2 is not positive definite)")
@@ -128,7 +128,7 @@ test_that("Running the AMIS integration should complete with the error about wei
 
     expect_error(AMISforInfectiousDiseases::amis(
         prevalence_map,
-        build_transmission_model(prevalence_map, example_parameters, year_indices = c(23)),
+        build_transmission_model(prevalence_map, example_parameters, year_indices = c(23), 2),
         prior,
         amis_params
     ), "(No weight on any particles for locations in the active set.)|(the leading minor of order 2 is not positive definite)")


### PR DESCRIPTION
Asking python how many CPUs there are does not respect the amount the cluster has actually allocated to the job, causing too many processes to be spawned. Instead, we let the R script be configured on the command line:

```
Rscript sth_fitting.R 10
```

To run with 10 jobs. Also added some basic logging that shows progress every 10 jobs completed with time taken. 