### PR TITLE
Accept absolute path for data location

### DIFF
--- a/sch_simulation/helsim_FUNC_KK/file_parsing.py
+++ b/sch_simulation/helsim_FUNC_KK/file_parsing.py
@@ -272,7 +272,7 @@ def parse_coverage_input(
                 Vacc_txt = Vacc_txt + str(VaccCoverages[k]) + " "
 
     # read in market share data
-    MarketShare = pd.read_excel(DATA_PATH + coverageFileName, sheet_name="MarketShare")
+    MarketShare = pd.read_excel(coverageFileName, sheet_name="MarketShare")
     # find which rows store data for MDAs
     MDAMarketShare = np.where(np.array(MarketShare["Platform"] == "MDA"))[0]
     # initialize variable to store which drug is being used

--- a/sch_simulation/helsim_FUNC_KK/file_parsing.py
+++ b/sch_simulation/helsim_FUNC_KK/file_parsing.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import warnings
 from typing import Any, Dict, List, Tuple, Union
 

--- a/sch_simulation/helsim_FUNC_KK/file_parsing.py
+++ b/sch_simulation/helsim_FUNC_KK/file_parsing.py
@@ -53,9 +53,13 @@ def readParam(fileName: str) -> Dict[str, Any]:
         dictionary containing the parameter names and values;
     """
 
-    DATA_PATH = pkg_resources.resource_filename("sch_simulation", "data/")
+    if not os.path.isabs(fileName):
+        fileName = os.path.join(
+            pkg_resources.resource_filename("sch_simulation", "data"),
+            fileName
+        )
 
-    with open(DATA_PATH + fileName) as f:
+    with open(fileName) as f:
         contents = f.readlines()
 
     return params_from_contents(contents)
@@ -103,9 +107,13 @@ def parse_coverage_input(
     """
 
     # read in Coverage spreadsheet
-    DATA_PATH = pkg_resources.resource_filename("sch_simulation", "data/")
+    if not os.path.isabs(coverageFileName):
+        coverageFileName = os.path.join(
+            pkg_resources.resource_filename("sch_simulation", "data"),
+            coverageFileName
+        )
     PlatCov = pd.read_excel(
-        DATA_PATH + coverageFileName, sheet_name="Platform Coverage"
+        coverageFileName, sheet_name="Platform Coverage"
     )
     # which rows are for MDA and vaccine
     intervention_array = PlatCov["Intervention Type"]


### PR DESCRIPTION
It's currently not possible to specify parameters and coverage data that is outside the `sch_simulation/data` directory.

This makes it so that if absolute paths are specified for the parameters file and/or coverage file, then this path is used instead
of looking into the `data/` directory.

Used in ??