### PR TITLE
Save pickle file

### DIFF
--- a/sch_simulation/amis_integration/amis_integration.R
+++ b/sch_simulation/amis_integration/amis_integration.R
@@ -5,7 +5,7 @@ get_amis_integration_package <- function() {
   return(sch_simulation)
 }
 
-build_transmission_model <- function(prevalence_map, fixed_parameters, year_indices, num_cores, save_final_state = FALSE) {
+build_transmission_model <- function(prevalence_map, fixed_parameters, year_indices, num_cores, final_state_config = NULL) {
   if(is.list(prevalence_map)) {
     if(length(prevalence_map) != length(year_indices)) {
       error_string <- sprintf("Length of prevalance map (%i) must match the number of years provided in year_indices (%i)", length(prevalence_map), length(year_indices))
@@ -25,7 +25,7 @@ build_transmission_model <- function(prevalence_map, fixed_parameters, year_indi
     output <- sch_simulation$run_model_with_parameters(
       # If year indices in just a single element, without as.array it will
       # automatically be converted into a scalar
-      seeds, params, fixed_parameters, as.array(year_indices_all), as.integer(num_cores), save_final_state
+      seeds, params, fixed_parameters, as.array(year_indices_all), as.integer(num_cores), final_state_config
     )
     colnames(output) = year_indices_all
     

--- a/sch_simulation/amis_integration/amis_integration.R
+++ b/sch_simulation/amis_integration/amis_integration.R
@@ -5,7 +5,7 @@ get_amis_integration_package <- function() {
   return(sch_simulation)
 }
 
-build_transmission_model <- function(prevalence_map, fixed_parameters, year_indices, num_cores) {
+build_transmission_model <- function(prevalence_map, fixed_parameters, year_indices, num_cores, save_final_state = FALSE) {
   if(is.list(prevalence_map)) {
     if(length(prevalence_map) != length(year_indices)) {
       error_string <- sprintf("Length of prevalance map (%i) must match the number of years provided in year_indices (%i)", length(prevalence_map), length(year_indices))
@@ -25,7 +25,7 @@ build_transmission_model <- function(prevalence_map, fixed_parameters, year_indi
     output <- sch_simulation$run_model_with_parameters(
       # If year indices in just a single element, without as.array it will
       # automatically be converted into a scalar
-      seeds, params, fixed_parameters, as.array(year_indices_all), as.integer(num_cores)
+      seeds, params, fixed_parameters, as.array(year_indices_all), as.integer(num_cores), save_final_state
     )
     colnames(output) = year_indices_all
     

--- a/sch_simulation/amis_integration/amis_integration.py
+++ b/sch_simulation/amis_integration/amis_integration.py
@@ -4,6 +4,7 @@ import os
 import time
 from typing import Literal
 import pandas as pd
+import pickle
 import sch_simulation
 import numpy as np
 from sch_simulation.helsim_FUNC_KK.configuration import setupSD
@@ -84,7 +85,7 @@ def returnYearlyPrevalenceEstimate(R0, k, seed, fixed_parameters: FixedParameter
     PrevalenceEstimate = results_processing.getPrevalenceWholePop(
         output, params, numReps, params.Unfertilized, fixed_parameters.survey_type, 1
     )
-    return PrevalenceEstimate
+    return PrevalenceEstimate, SD
 
 
 def extract_relevant_results(
@@ -110,17 +111,18 @@ def run_and_extract_results(parameter_set, seed, fixed_parameters, year_indices,
 
     start_time = time.time()
 
-    results = returnYearlyPrevalenceEstimate(R0, k, seed, fixed_parameters)
+    results, end_state = returnYearlyPrevalenceEstimate(R0, k, seed, fixed_parameters)
 
     end_time = time.time()
     if include_output:
         print(f'Run R0: {R0}, k: {k} took {end_time-start_time:10.2f} seconds')
 
-    return extract_relevant_results(results, year_indices)
+    return extract_relevant_results(results, year_indices), end_state
 
 def run_model_with_parameters(
     seeds, parameters, fixed_parameters: FixedParameters, year_indices: list[int],
-    num_parallel_jobs = -2 # default to all but one process to keep computers responsive
+    num_parallel_jobs = -2, # default to all but one process to keep computers responsive
+    should_save_state=False,
 ):
     if len(seeds) != len(parameters):
         raise ValueError(
@@ -138,13 +140,24 @@ def run_model_with_parameters(
 
     print_timing_info_every_n_times = 10
 
-    final_prevalence_for_each_run = Parallel(n_jobs=num_parallel_jobs)(delayed(run_and_extract_results)
+    run_results = Parallel(n_jobs=num_parallel_jobs)(delayed(run_and_extract_results)
         (parameter_set, seed, fixed_parameters, year_indices, include_output=index % print_timing_info_every_n_times == 0) 
         for index, (seed, parameter_set) in enumerate(zip(seeds, parameters)))
+    
+    final_prevalence_for_each_run = list(
+        map(lambda run_result: run_result[0], run_results)
+    )
 
     results_np_array = np.array(final_prevalence_for_each_run).reshape(
         num_runs, len(year_indices)
     )
+
+    if should_save_state:
+        final_states = list(map(lambda run_result: run_result[1], run_results))
+        print("Saving pickle files")
+        for index, final_state in enumerate(final_states):
+            with open(f"final_state_{index}.pickle", "wb") as pickle_file:
+                pickle.dump(final_state, pickle_file)
 
     os.remove(fixed_parameters.coverage_text_file_storage_name)
 

--- a/sch_simulation/amis_integration/amis_integration.py
+++ b/sch_simulation/amis_integration/amis_integration.py
@@ -48,6 +48,11 @@ class FixedParameters:
     
     A higher number will result in faster but less accurate simulation."""
 
+@dataclass(eq=True, frozen=True)
+class StateSnapshotConfig:
+    directory: str = "."
+    name_prefix: str = "final_state"
+
 
 def returnYearlyPrevalenceEstimate(R0, k, seed, fixed_parameters: FixedParameters):
     np.random.seed(seed)
@@ -122,7 +127,7 @@ def run_and_extract_results(parameter_set, seed, fixed_parameters, year_indices,
 def run_model_with_parameters(
     seeds, parameters, fixed_parameters: FixedParameters, year_indices: list[int],
     num_parallel_jobs = -2, # default to all but one process to keep computers responsive
-    should_save_state=False,
+    final_state_config: StateSnapshotConfig | None = None,
 ):
     if len(seeds) != len(parameters):
         raise ValueError(
@@ -152,11 +157,16 @@ def run_model_with_parameters(
         num_runs, len(year_indices)
     )
 
-    if should_save_state:
+    if final_state_config is not None:
+        if not os.path.exists(final_state_config.directory):
+            os.makedirs(final_state_config.directory)
         final_states = list(map(lambda run_result: run_result[1], run_results))
         print("Saving pickle files")
         for index, final_state in enumerate(final_states):
-            with open(f"final_state_{index}.pickle", "wb") as pickle_file:
+            with open(
+                f"{final_state_config.directory}/{final_state_config.name_prefix}_{index}.pickle",
+                "wb",
+            ) as pickle_file:
                 pickle.dump(final_state, pickle_file)
 
     os.remove(fixed_parameters.coverage_text_file_storage_name)

--- a/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
+++ b/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
@@ -69,6 +69,21 @@ test_that("Running the simulation with different number of years specified compa
     expect_error(build_transmission_model(prevalence_map, example_parameters, year_indices, 2), "Length of prevalance map \\(2\\) must match the number of years provided in year_indices \\(1\\)")
 })
 
+test_that("Runnig the simulation and requesting saving the state saves the state", {
+    prevalence_map <- vector("list", 2)
+    prevalence_map[[1]]$data <- matrix(c(0.031, 0.031))
+    prevalence_map[[2]]$data <- matrix(c(0.021, 0.021))
+
+    year_indices <- c(0L, 23L)
+
+    tranmission_model <- build_transmission_model(prevalence_map, example_parameters, year_indices, 2, save_final_state = TRUE)
+    result <- tranmission_model(c(1L, 2L), matrix(c(3, 3, 0.3, 0.3), ncol = 2), 1)
+    expect_true(file.exists("final_state_0.pickle"))
+    expect_true(file.exists("final_state_1.pickle"))
+    file.remove("final_state_0.pickle")
+    file.remove("final_state_1.pickle")
+})
+
 test_that("Running the AMIS integration on multiple time points should complete with the error about weight on particles", {
     # Example prevalence map, with two locations, fitting to two time times
     # Both locations start at 0.031, and the second time point is 0.021

--- a/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
+++ b/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
@@ -32,6 +32,9 @@ test_that("Running the model should give us consistent results", {
     tranmission_model <- build_transmission_model(prevalence_map, example_parameters, year_indices = c(23), 2)
     result <- tranmission_model(c(1L, 2L), matrix(c(3, 3, 0.3, 0.3), ncol = 2), 1)
     expect_equal(result, matrix(c(0.0, 0.5), ncol = 1), tolerance = 0.0)
+
+    # Verify no pickle file is created
+    expect_false(file.exists("_0.pickle"))
 })
 
 test_that("Running the simulation on multiple time points gives multiple points back", {
@@ -76,12 +79,17 @@ test_that("Runnig the simulation and requesting saving the state saves the state
 
     year_indices <- c(0L, 23L)
 
-    tranmission_model <- build_transmission_model(prevalence_map, example_parameters, year_indices, 2, save_final_state = TRUE)
+    final_state_config <- sch_simulation$StateSnapshotConfig(
+        directory = "nested_dir", name_prefix = "file_prefix"
+    )
+
+    tranmission_model <- build_transmission_model(prevalence_map, example_parameters, year_indices, 2, final_state_config = final_state_config)
     result <- tranmission_model(c(1L, 2L), matrix(c(3, 3, 0.3, 0.3), ncol = 2), 1)
-    expect_true(file.exists("final_state_0.pickle"))
-    expect_true(file.exists("final_state_1.pickle"))
-    file.remove("final_state_0.pickle")
-    file.remove("final_state_1.pickle")
+    expect_true(file.exists("nested_dir/file_prefix_0.pickle"))
+    expect_true(file.exists("nested_dir/file_prefix_1.pickle"))
+    file.remove("nested_dir/file_prefix_0.pickle")
+    file.remove("nested_dir/file_prefix_1.pickle")
+    unlink("nested_dir")
 })
 
 test_that("Running the AMIS integration on multiple time points should complete with the error about weight on particles", {

--- a/tests/amis_integration/test_amis_integration.py
+++ b/tests/amis_integration/test_amis_integration.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from sch_simulation.amis_integration.amis_integration import extract_relevant_results, returnYearlyPrevalenceEstimate, FixedParameters, run_model_with_parameters
+from sch_simulation.amis_integration.amis_integration import StateSnapshotConfig, extract_relevant_results, returnYearlyPrevalenceEstimate, FixedParameters, run_model_with_parameters
 import pandas as pd
 from pandas import testing as pdt
 from numpy import testing as npt
@@ -57,10 +57,38 @@ def test_running_save_state_saves_state():
         fixed_parameters=example_parameters,
         year_indices=[23],
         num_parallel_jobs=2,
-        should_save_state=True,
+        final_state_config=StateSnapshotConfig(),
     )
     assert os.path.exists("final_state_0.pickle")
     os.remove("final_state_0.pickle")
+
+
+def test_running_save_state_saves_state_in_nested_dir():
+    _ = run_model_with_parameters(
+        seeds=[1],
+        parameters=[(3.0, 0.3)],
+        fixed_parameters=example_parameters,
+        year_indices=[23],
+        num_parallel_jobs=2,
+        final_state_config=StateSnapshotConfig(
+            directory="nested_dir", name_prefix="file_prefix"
+        ),
+    )
+    assert os.path.exists("nested_dir/file_prefix_0.pickle")
+    os.remove("nested_dir/file_prefix_0.pickle")
+    os.rmdir("nested_dir/")
+
+def test_running_None_save_state_does_not_save_state():
+    _ = run_model_with_parameters(
+        seeds=[1],
+        parameters=[(3.0, 0.3)],
+        fixed_parameters=example_parameters,
+        year_indices=[23],
+        num_parallel_jobs=2,
+        final_state_prefix=None,
+    )
+    assert not os.path.exists("_0.pickle")
+
 
 def test_running_model_with_different_seed_gives_different_result():
     parse_coverage_input(

--- a/tests/amis_integration/test_amis_integration.py
+++ b/tests/amis_integration/test_amis_integration.py
@@ -36,8 +36,8 @@ def test_running_model_produces_consistent_result():
 
     results_with_seed1 = returnYearlyPrevalenceEstimate(3.0, 0.3, seed=1, fixed_parameters=example_parameters)
     print(results_with_seed1['draw_1'])
-    expected_prevalance = [0.1, 0.2, 0.3, 0.3, 0.2, 0.0, 0.1, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    pdt.assert_series_equal(results_with_seed1['draw_1'], pd.Series(expected_prevalance, name="draw_1"))
+    expected_prevalence = [0.1, 0.2, 0.3, 0.3, 0.2, 0.0, 0.1, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    pdt.assert_series_equal(results_with_seed1['draw_1'], pd.Series(expected_prevalence, name="draw_1"))
 
 def test_running_parallel_produces_results():
     results = run_model_with_parameters(

--- a/tests/amis_integration/test_amis_integration.py
+++ b/tests/amis_integration/test_amis_integration.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from sch_simulation.amis_integration.amis_integration import extract_relevant_results, returnYearlyPrevalenceEstimate, FixedParameters, run_model_with_parameters
 import pandas as pd
@@ -48,6 +49,18 @@ def test_running_parallel_produces_results():
         num_parallel_jobs=2)
     print(results)
     npt.assert_array_equal(results, [[0. ],[0.5],[0.4],[0.8]])
+
+def test_running_save_state_saves_state():
+    _ = run_model_with_parameters(
+        seeds=[1],
+        parameters=[(3.0, 0.3)],
+        fixed_parameters=example_parameters,
+        year_indices=[23],
+        num_parallel_jobs=2,
+        should_save_state=True,
+    )
+    assert os.path.exists("final_state_0.pickle")
+    os.remove("final_state_0.pickle")
 
 def test_running_model_with_different_seed_gives_different_result():
     parse_coverage_input(


### PR DESCRIPTION
Added support to be able to write out the pickle file that is generated at the end of the simulation. 

The new tests do work, but the tests currently fail due to changes made in #70 (which this will merge into). 

@RaihaTuiTaura - if you end up running the near term simulations (e.g. up to 2026) for STH this will be useful for making sure we save the pickle files at the end so we can easily resume for the full projections.