### PR TITLE
Single pickle file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"] # Test oldest and newest supported Python
+        python-version: ["3.10.4"] # Test on version used on cluster
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -34,4 +34,3 @@ jobs:
     - name: Run R tests
       run: Rscript tests/testthat.R
       working-directory: 'sch_simulation/amis_integration'
-

--- a/sch_simulation/amis_integration/amis_integration.py
+++ b/sch_simulation/amis_integration/amis_integration.py
@@ -162,12 +162,12 @@ def run_model_with_parameters(
             os.makedirs(final_state_config.directory)
         final_states = list(map(lambda run_result: run_result[1], run_results))
         print("Saving pickle files")
-        for index, final_state in enumerate(final_states):
-            with open(
-                f"{final_state_config.directory}/{final_state_config.name_prefix}_{index}.pickle",
+        with open(
+                f"{final_state_config.directory}/{final_state_config.name_prefix}.p",
                 "wb",
             ) as pickle_file:
-                pickle.dump(final_state, pickle_file)
+                pickle.dump(final_states, pickle_file)
+            
 
     os.remove(fixed_parameters.coverage_text_file_storage_name)
 

--- a/tests/amis_integration/test_amis_integration.py
+++ b/tests/amis_integration/test_amis_integration.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 import pytest
 from sch_simulation.amis_integration.amis_integration import StateSnapshotConfig, extract_relevant_results, returnYearlyPrevalenceEstimate, FixedParameters, run_model_with_parameters
 import pandas as pd
@@ -6,6 +7,7 @@ from pandas import testing as pdt
 from numpy import testing as npt
 
 from sch_simulation.helsim_FUNC_KK.file_parsing import parse_coverage_input
+from sch_simulation.helsim_FUNC_KK.helsim_structures import SDEquilibrium
 
 example_parameters = FixedParameters(
         # the higher the value of N, the more consistent the results will be
@@ -59,8 +61,15 @@ def test_running_save_state_saves_state():
         num_parallel_jobs=2,
         final_state_config=StateSnapshotConfig(),
     )
-    assert os.path.exists("final_state_0.pickle")
-    os.remove("final_state_0.pickle")
+    assert os.path.exists("final_state.p")
+
+    with open("final_state.p", "rb") as f:
+        pickle_data = pickle.load(f)
+    print(type(pickle_data))
+    assert type(pickle_data) is list
+    assert len(pickle_data) == 1
+    assert type(pickle_data[0]) is SDEquilibrium
+    os.remove("final_state.p")
 
 
 def test_running_save_state_saves_state_in_nested_dir():
@@ -74,8 +83,8 @@ def test_running_save_state_saves_state_in_nested_dir():
             directory="nested_dir", name_prefix="file_prefix"
         ),
     )
-    assert os.path.exists("nested_dir/file_prefix_0.pickle")
-    os.remove("nested_dir/file_prefix_0.pickle")
+    assert os.path.exists("nested_dir/file_prefix.p")
+    os.remove("nested_dir/file_prefix.p")
     os.rmdir("nested_dir/")
 
 def test_running_None_save_state_does_not_save_state():
@@ -87,7 +96,26 @@ def test_running_None_save_state_does_not_save_state():
         num_parallel_jobs=2,
         final_state_config=None,
     )
-    assert not os.path.exists("_0.pickle")
+    assert not os.path.exists(".p")
+
+
+def test_running_two_saves_one_pickle_file_as_list():
+    _ = run_model_with_parameters(
+        seeds=[1,2],
+        parameters=[(3.0, 0.3), (3.0, 0.3)],
+        fixed_parameters=example_parameters,
+        year_indices=[23],
+        num_parallel_jobs=2,
+        final_state_config=StateSnapshotConfig(),
+    )
+    assert os.path.exists("final_state.p")
+
+    with open("final_state.p", "rb") as f:
+        pickle_data = pickle.load(f)
+    print(type(pickle_data))
+    assert type(pickle_data) is list
+    assert len(pickle_data) == 2
+    os.remove("final_state.p") 
 
 
 def test_running_model_with_different_seed_gives_different_result():

--- a/tests/amis_integration/test_amis_integration.py
+++ b/tests/amis_integration/test_amis_integration.py
@@ -35,7 +35,7 @@ def test_running_model_produces_consistent_result():
         example_parameters.coverage_text_file_storage_name,
     )
 
-    results_with_seed1 = returnYearlyPrevalenceEstimate(3.0, 0.3, seed=1, fixed_parameters=example_parameters)
+    results_with_seed1, _ = returnYearlyPrevalenceEstimate(3.0, 0.3, seed=1, fixed_parameters=example_parameters)
     print(results_with_seed1['draw_1'])
     expected_prevalence = [0.1, 0.2, 0.3, 0.3, 0.2, 0.0, 0.1, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     pdt.assert_series_equal(results_with_seed1['draw_1'], pd.Series(expected_prevalence, name="draw_1"))
@@ -85,7 +85,7 @@ def test_running_None_save_state_does_not_save_state():
         fixed_parameters=example_parameters,
         year_indices=[23],
         num_parallel_jobs=2,
-        final_state_prefix=None,
+        final_state_config=None,
     )
     assert not os.path.exists("_0.pickle")
 


### PR DESCRIPTION
Now only create one pickle file per IU (previously output each of the stochasic set of runs as its own output, now compiles them into a list and outputs that so just 5000 pickle files, rather than 5000 * 200 (about a millon)!! 

- [x] Fix naming
- [x] Fix R scripts and tests