### PR TITLE
update to use SAC prevalence for amis

### DIFF
--- a/sch_simulation/amis_integration/amis_integration.py
+++ b/sch_simulation/amis_integration/amis_integration.py
@@ -81,8 +81,8 @@ def returnYearlyPrevalenceEstimate(R0, k, seed, fixed_parameters: FixedParameter
 
     # do a single simulation
     numReps = 1
-    PrevalenceEstimate = results_processing.getPrevalenceWholePop(
-        output, params, numReps, params.Unfertilized, fixed_parameters.survey_type, 1
+    PrevalenceEstimate = results_processing.getPrevalence(
+        output, params, numReps, params.Unfertilized
     )
     return PrevalenceEstimate
 

--- a/sch_simulation/amis_integration/amis_integration.py
+++ b/sch_simulation/amis_integration/amis_integration.py
@@ -18,6 +18,7 @@ from joblib import Parallel, delayed
 import sch_simulation.helsim_RUN_KK
 
 import sch_simulation.helsim_FUNC_KK.results_processing as results_processing
+import sch_simulation.helsim_FUNC_KK.prevalence_column_names as prevalence_column_names
 
 @dataclass(eq=True, frozen=True)
 class FixedParameters:
@@ -93,7 +94,7 @@ def extract_relevant_results(
 
     relevant_rows = results["Time"].isin(relevant_years)
     prevalence_for_relevant_years = pd.Series(
-        data=results[relevant_rows]["SAC Prevalence"],
+        data=results[relevant_rows][prevalence_column_names.SAC_PREVALENCE],
         index=relevant_years,
         name="Prevalence",
     )

--- a/sch_simulation/amis_integration/amis_integration.py
+++ b/sch_simulation/amis_integration/amis_integration.py
@@ -93,7 +93,7 @@ def extract_relevant_results(
 
     relevant_rows = results["Time"].isin(relevant_years)
     prevalence_for_relevant_years = pd.Series(
-        data=results[relevant_rows][results_processing.OUTPUT_COLUMN_NAME],
+        data=results[relevant_rows]["SAC Prevalence"],
         index=relevant_years,
         name="Prevalence",
     )

--- a/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
+++ b/sch_simulation/amis_integration/tests/testthat/test-amis-integration.R
@@ -31,7 +31,7 @@ test_that("Running the model should give us consistent results", {
 
     tranmission_model <- build_transmission_model(prevalence_map, example_parameters, year_indices = c(23), 2)
     result <- tranmission_model(c(1L, 2L), matrix(c(3, 3, 0.3, 0.3), ncol = 2), 1)
-    expect_equal(result, matrix(c(0.0, 0.5), ncol = 1), tolerance = 0.0)
+    expect_equal(result, matrix(c(0.0, 0.29), ncol = 1), tolerance = 0.0)
 })
 
 test_that("Running the simulation on multiple time points gives multiple points back", {

--- a/sch_simulation/helsim_FUNC_KK/prevalence_column_names.py
+++ b/sch_simulation/helsim_FUNC_KK/prevalence_column_names.py
@@ -1,0 +1,5 @@
+TIME = "Time"
+SAC_PREVALENCE = "SAC Prevalence"
+ADULT_PREVALENCE = "Adult Prevalence"
+SAC_HEAVY_INTENSITY_PREVALENCE = "SAC Heavy Intensity Prevalence"
+ADULT_HEAVY_INTENSITY_PREVALENCE = "Adult Heavy Intensity Prevalence"

--- a/sch_simulation/helsim_FUNC_KK/results_processing.py
+++ b/sch_simulation/helsim_FUNC_KK/results_processing.py
@@ -774,6 +774,8 @@ def getPrevalence(
     Returns
     -------
     data frame with SAC and adult prevalence at each time point;
+    See prevalence_column_names for the names of the columns that are
+    present in this dataframe.
     """
 
     sac_results = np.array(

--- a/sch_simulation/helsim_FUNC_KK/results_processing.py
+++ b/sch_simulation/helsim_FUNC_KK/results_processing.py
@@ -20,7 +20,7 @@ np.seterr(divide="ignore")
 
 # When running a single simulation the output is always put in a column called
 # draw_1.
-OUTPUT_COLUMN_NAME = "draw_1"
+OUTPUT_COLUMN_NAME = "SAC Prevalence"
 
 def extractHostData(results: List[List[Result]]) -> List[ProcResult]:
 

--- a/sch_simulation/helsim_FUNC_KK/results_processing.py
+++ b/sch_simulation/helsim_FUNC_KK/results_processing.py
@@ -20,7 +20,7 @@ np.seterr(divide="ignore")
 
 # When running a single simulation the output is always put in a column called
 # draw_1.
-OUTPUT_COLUMN_NAME = "SAC Prevalence"
+OUTPUT_COLUMN_NAME = "draw_1"
 
 def extractHostData(results: List[List[Result]]) -> List[ProcResult]:
 

--- a/tests/amis_integration/test_amis_integration.py
+++ b/tests/amis_integration/test_amis_integration.py
@@ -3,8 +3,9 @@ from sch_simulation.amis_integration.amis_integration import extract_relevant_re
 import pandas as pd
 from pandas import testing as pdt
 from numpy import testing as npt
-
+import sch_simulation.helsim_FUNC_KK.results_processing as results_processing
 from sch_simulation.helsim_FUNC_KK.file_parsing import parse_coverage_input
+
 
 example_parameters = FixedParameters(
         # the higher the value of N, the more consistent the results will be
@@ -33,11 +34,10 @@ def test_running_model_produces_consistent_result():
         example_parameters.coverage_file_name,
         example_parameters.coverage_text_file_storage_name,
     )
-
     results_with_seed1 = returnYearlyPrevalenceEstimate(3.0, 0.3, seed=1, fixed_parameters=example_parameters)
-    print(results_with_seed1['draw_1'])
+    print(results_with_seed1[results_processing.OUTPUT_COLUMN_NAME])
     expected_prevalance = [0.1, 0.2, 0.3, 0.3, 0.2, 0.0, 0.1, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    pdt.assert_series_equal(results_with_seed1['draw_1'], pd.Series(expected_prevalance, name="draw_1"))
+    pdt.assert_series_equal(results_with_seed1[results_processing.OUTPUT_COLUMN_NAME], pd.Series(expected_prevalance, name=results_processing.OUTPUT_COLUMN_NAME))
 
 def test_running_parallel_produces_results():
     results = run_model_with_parameters(
@@ -61,7 +61,7 @@ def test_running_model_with_different_seed_gives_different_result():
         pdt.assert_frame_equal(results_with_seed1, results_with_seed2)
 
 def test_extract_data():
-    example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], "draw_1": [0.1, 0.2, 0.3]})
+    example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], results_processing.OUTPUT_COLUMN_NAME: [0.1, 0.2, 0.3]})
     outcome = extract_relevant_results(example_results, [2.0])
     pdt.assert_series_equal(
         outcome, pd.Series(data=[0.3], index=[2.0], name="Prevalence")
@@ -69,7 +69,7 @@ def test_extract_data():
 
 
 def test_extract_multiple_years():
-    example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], "draw_1": [0.1, 0.2, 0.3]})
+    example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], results_processing.OUTPUT_COLUMN_NAME: [0.1, 0.2, 0.3]})
     outcome = extract_relevant_results(example_results, [0.0, 2.0])
     pdt.assert_series_equal(
         outcome, pd.Series(data=[0.1, 0.3], index=[0.0, 2.0], name="Prevalence")
@@ -77,6 +77,6 @@ def test_extract_multiple_years():
 
 
 def test_extract_missing_year():
-    example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], "draw_1": [0.1, 0.2, 0.3]})
+    example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], results_processing.OUTPUT_COLUMN_NAME: [0.1, 0.2, 0.3]})
     with pytest.raises(ValueError):
         outcome = extract_relevant_results(example_results, [3.0])

--- a/tests/amis_integration/test_amis_integration.py
+++ b/tests/amis_integration/test_amis_integration.py
@@ -36,7 +36,7 @@ def test_running_model_produces_consistent_result():
     )
     results_with_seed1 = returnYearlyPrevalenceEstimate(3.0, 0.3, seed=1, fixed_parameters=example_parameters)
     print(results_with_seed1[results_processing.OUTPUT_COLUMN_NAME])
-    expected_prevalance = [0.1, 0.2, 0.3, 0.3, 0.2, 0.0, 0.1, 0.1, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    expected_prevalance = [0.0, 0.0, 0.0, 0.31, 0.3, 0.0, 0.44, 0.0, 0.49, 0.57, 0.25, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     pdt.assert_series_equal(results_with_seed1[results_processing.OUTPUT_COLUMN_NAME], pd.Series(expected_prevalance, name=results_processing.OUTPUT_COLUMN_NAME))
 
 def test_running_parallel_produces_results():
@@ -47,7 +47,7 @@ def test_running_parallel_produces_results():
         year_indices=[23],
         num_parallel_jobs=2)
     print(results)
-    npt.assert_array_equal(results, [[0. ],[0.5],[0.4],[0.8]])
+    npt.assert_array_equal(results, [[0.  ],[0.29],[0.  ],[1.  ]])
 
 def test_running_model_with_different_seed_gives_different_result():
     parse_coverage_input(

--- a/tests/amis_integration/test_amis_integration.py
+++ b/tests/amis_integration/test_amis_integration.py
@@ -35,9 +35,9 @@ def test_running_model_produces_consistent_result():
         example_parameters.coverage_text_file_storage_name,
     )
     results_with_seed1 = returnYearlyPrevalenceEstimate(3.0, 0.3, seed=1, fixed_parameters=example_parameters)
-    print(results_with_seed1[results_processing.OUTPUT_COLUMN_NAME])
+    print(results_with_seed1["SAC Prevalence"])
     expected_prevalance = [0.0, 0.0, 0.0, 0.31, 0.3, 0.0, 0.44, 0.0, 0.49, 0.57, 0.25, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    pdt.assert_series_equal(results_with_seed1[results_processing.OUTPUT_COLUMN_NAME], pd.Series(expected_prevalance, name=results_processing.OUTPUT_COLUMN_NAME))
+    pdt.assert_series_equal(results_with_seed1["SAC Prevalence"], pd.Series(expected_prevalance, name="SAC Prevalence"))
 
 def test_running_parallel_produces_results():
     results = run_model_with_parameters(
@@ -61,7 +61,7 @@ def test_running_model_with_different_seed_gives_different_result():
         pdt.assert_frame_equal(results_with_seed1, results_with_seed2)
 
 def test_extract_data():
-    example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], results_processing.OUTPUT_COLUMN_NAME: [0.1, 0.2, 0.3]})
+    example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], "SAC Prevalence": [0.1, 0.2, 0.3]})
     outcome = extract_relevant_results(example_results, [2.0])
     pdt.assert_series_equal(
         outcome, pd.Series(data=[0.3], index=[2.0], name="Prevalence")
@@ -69,7 +69,7 @@ def test_extract_data():
 
 
 def test_extract_multiple_years():
-    example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], results_processing.OUTPUT_COLUMN_NAME: [0.1, 0.2, 0.3]})
+    example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], "SAC Prevalence": [0.1, 0.2, 0.3]})
     outcome = extract_relevant_results(example_results, [0.0, 2.0])
     pdt.assert_series_equal(
         outcome, pd.Series(data=[0.1, 0.3], index=[0.0, 2.0], name="Prevalence")
@@ -77,6 +77,6 @@ def test_extract_multiple_years():
 
 
 def test_extract_missing_year():
-    example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], results_processing.OUTPUT_COLUMN_NAME: [0.1, 0.2, 0.3]})
+    example_results = pd.DataFrame({"Time": [0.0, 1.0, 2.0], "SAC Prevalence": [0.1, 0.2, 0.3]})
     with pytest.raises(ValueError):
         outcome = extract_relevant_results(example_results, [3.0])


### PR DESCRIPTION
AMIS for SCH/STH model fits to whole population prevalence to the data, but this data is for school age children. Change the output of the model for the AMIS model to be school age children not whole population prevalence.