### PR TITLE
correct the number of samples used for getBurdens

### DIFF
--- a/sch_simulation/helsim_FUNC_KK/results_processing.py
+++ b/sch_simulation/helsim_FUNC_KK/results_processing.py
@@ -612,17 +612,12 @@ def getBurdens(
     mean_eggs = np.empty((0, numReps))
     for t in range(len(hostData[0].timePoints)):  # loop over time points
         # calculate burdens using the same sample
-        #newrow = np.array(
-        #  getSampledDetectedPrevByVillageAll(
-        #        hostData, t, ageBand, params, Unfertilized, surveyType, nSamples, villageSampleSize
-        #    )
-        #)
-        
         newrow = np.array(
-            getSampledDetectedPrevByVillageAll(
-                hostData, t, ageBand, params, Unfertilized, surveyType, 1, villageSampleSize
-            )
+         getSampledDetectedPrevByVillageAll(
+               hostData, t, ageBand, params, Unfertilized, surveyType, nSamples, villageSampleSize
+           )
         )
+        
         newrowinfected = newrow[:, 0]
         newrowlow = newrow[:, 1]
         newrowmedium = newrow[:, 2]


### PR DESCRIPTION
the `nSamples` used within the `getBurdens` was hard coded as 1, rather then taking the entry from the inputs. This is edited to take the value from the inputs. 

This function will be used to generate the IHME and prevalence outputs, so we need to have this included in the code to output these data. The fits which have been done didn't rely on this function, so there wasn't an issue with the outputs from the model. 